### PR TITLE
feat: add interactive dispatch board layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,428 @@
-import BookingCard from "./components/BookingCard";
-import VehicleDispatchBoardMock from "./components/VehicleDispatchBoardMock";
+import { useMemo, useReducer } from "react";
+import { DragDropContext, type DropResult } from "react-beautiful-dnd";
+import DispatchBoardLayout from "./components/DispatchBoardLayout";
+import DriverPool from "./components/DriverPool";
+import JobPool from "./components/JobPool";
+import MotorPoolTimeline from "./components/MotorPoolTimeline";
+import type { Driver, Job, Reservation } from "./data/mockData";
+import { mockDrivers, mockJobs, mockLanes, mockReservations } from "./data/mockData";
 
-function App() {
-  return (
-    <div className="min-h-screen bg-slate-50 p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Vehicle Dispatch Board (mock)</h1>
-      <BookingCard />
-      <VehicleDispatchBoardMock />
+type DispatchState = {
+  jobs: Record<string, Job>;
+  jobOrder: string[];
+  drivers: Record<string, Driver>;
+  driverOrder: string[];
+  reservations: Record<string, Reservation>;
+  lanes: Record<string, { id: string; name: string; reservationIds: string[] }>;
+  laneOrder: string[];
+};
+
+type DispatchAction =
+  | {
+      type: "MOVE_RESERVATION";
+      reservationId: string;
+      sourceLaneId: string;
+      destinationLaneId: string;
+      sourceIndex: number;
+      destinationIndex: number;
+    }
+  | { type: "ASSIGN_JOB"; jobId: string; reservationId: string }
+  | { type: "UNASSIGN_JOB"; jobId: string; reservationId: string }
+  | { type: "ASSIGN_DRIVER"; driverId: string; reservationId: string }
+  | { type: "UNASSIGN_DRIVER"; driverId: string; reservationId: string };
+
+const buildInitialState = (): DispatchState => {
+  const jobs: Record<string, Job> = {};
+  const drivers: Record<string, Driver> = {};
+  const reservations: Record<string, Reservation> = {};
+  const lanes: DispatchState["lanes"] = {};
+
+  mockJobs.forEach((job) => {
+    jobs[job.id] = { ...job };
+  });
+
+  mockDrivers.forEach((driver) => {
+    drivers[driver.id] = { ...driver };
+  });
+
+  mockReservations.forEach((reservation) => {
+    reservations[reservation.id] = { ...reservation };
+  });
+
+  mockLanes.forEach((lane) => {
+    lanes[lane.id] = { ...lane };
+  });
+
+  return {
+    jobs,
+    jobOrder: mockJobs.map((job) => job.id),
+    drivers,
+    driverOrder: mockDrivers.map((driver) => driver.id),
+    reservations,
+    lanes,
+    laneOrder: mockLanes.map((lane) => lane.id)
+  };
+};
+
+const releaseDriverFromReservation = (
+  state: DispatchState,
+  reservationId: string
+): DispatchState => {
+  const reservation = state.reservations[reservationId];
+  if (!reservation?.driverId) {
+    return state;
+  }
+  const driverId = reservation.driverId;
+  const driver = state.drivers[driverId];
+  if (!driver) {
+    return state;
+  }
+  return {
+    ...state,
+    drivers: {
+      ...state.drivers,
+      [driverId]: { ...driver, status: "available", assignedReservationId: undefined }
+    },
+    reservations: {
+      ...state.reservations,
+      [reservationId]: { ...reservation, driverId: undefined }
+    }
+  };
+};
+
+const reducer = (state: DispatchState, action: DispatchAction): DispatchState => {
+  switch (action.type) {
+    case "MOVE_RESERVATION": {
+      const { reservationId, sourceLaneId, destinationLaneId, sourceIndex, destinationIndex } = action;
+      const sourceLane = state.lanes[sourceLaneId];
+      const destinationLane = state.lanes[destinationLaneId];
+      if (!sourceLane || !destinationLane) {
+        return state;
+      }
+
+      const updatedSourceIds = Array.from(sourceLane.reservationIds);
+      updatedSourceIds.splice(sourceIndex, 1);
+
+      if (sourceLaneId === destinationLaneId) {
+        updatedSourceIds.splice(destinationIndex, 0, reservationId);
+        return {
+          ...state,
+          lanes: {
+            ...state.lanes,
+            [sourceLaneId]: { ...sourceLane, reservationIds: updatedSourceIds }
+          }
+        };
+      }
+
+      const updatedDestinationIds = Array.from(destinationLane.reservationIds);
+      updatedDestinationIds.splice(destinationIndex, 0, reservationId);
+
+      return {
+        ...state,
+        lanes: {
+          ...state.lanes,
+          [sourceLaneId]: { ...sourceLane, reservationIds: updatedSourceIds },
+          [destinationLaneId]: { ...destinationLane, reservationIds: updatedDestinationIds }
+        },
+        reservations: {
+          ...state.reservations,
+          [reservationId]: { ...state.reservations[reservationId], laneId: destinationLaneId }
+        }
+      };
+    }
+    case "ASSIGN_JOB": {
+      const { jobId, reservationId } = action;
+      const job = state.jobs[jobId];
+      const reservation = state.reservations[reservationId];
+      if (!job || !reservation) {
+        return state;
+      }
+
+      let nextState: DispatchState = state;
+
+      if (job.reservationId && job.reservationId !== reservationId) {
+        const previousReservation = state.reservations[job.reservationId];
+        if (previousReservation) {
+          nextState = {
+            ...nextState,
+            reservations: {
+              ...nextState.reservations,
+              [job.reservationId]: { ...previousReservation, jobId: undefined }
+            }
+          };
+        }
+      }
+
+      if (reservation.jobId && reservation.jobId !== jobId) {
+        const displacedJob = state.jobs[reservation.jobId];
+        if (displacedJob) {
+          nextState = {
+            ...nextState,
+            jobs: {
+              ...nextState.jobs,
+              [reservation.jobId]: { ...displacedJob, reservationId: undefined, status: "unassigned" }
+            }
+          };
+        }
+      }
+
+      return {
+        ...nextState,
+        jobs: {
+          ...nextState.jobs,
+          [jobId]: { ...job, reservationId, status: "scheduled" }
+        },
+        reservations: {
+          ...nextState.reservations,
+          [reservationId]: { ...nextState.reservations[reservationId], jobId }
+        }
+      };
+    }
+    case "UNASSIGN_JOB": {
+      const { jobId, reservationId } = action;
+      const job = state.jobs[jobId];
+      const reservation = state.reservations[reservationId];
+      if (!job || !reservation) {
+        return state;
+      }
+
+      const stateWithoutDriver = releaseDriverFromReservation(state, reservationId);
+
+      return {
+        ...stateWithoutDriver,
+        jobs: {
+          ...stateWithoutDriver.jobs,
+          [jobId]: { ...job, reservationId: undefined, status: "unassigned" }
+        },
+        reservations: {
+          ...stateWithoutDriver.reservations,
+          [reservationId]: { ...stateWithoutDriver.reservations[reservationId], jobId: undefined }
+        }
+      };
+    }
+    case "ASSIGN_DRIVER": {
+      const { driverId, reservationId } = action;
+      const driver = state.drivers[driverId];
+      const reservation = state.reservations[reservationId];
+      if (!driver || !reservation) {
+        return state;
+      }
+
+      let nextState: DispatchState = state;
+
+      if (driver.assignedReservationId && driver.assignedReservationId !== reservationId) {
+        const previousReservation = state.reservations[driver.assignedReservationId];
+        if (previousReservation) {
+          nextState = {
+            ...nextState,
+            reservations: {
+              ...nextState.reservations,
+              [driver.assignedReservationId]: { ...previousReservation, driverId: undefined }
+            }
+          };
+        }
+      }
+
+      if (reservation.driverId && reservation.driverId !== driverId) {
+        const replacedDriver = state.drivers[reservation.driverId];
+        if (replacedDriver) {
+          nextState = {
+            ...nextState,
+            drivers: {
+              ...nextState.drivers,
+              [reservation.driverId]: {
+                ...replacedDriver,
+                status: "available",
+                assignedReservationId: undefined
+              }
+            }
+          };
+        }
+      }
+
+      return {
+        ...nextState,
+        drivers: {
+          ...nextState.drivers,
+          [driverId]: { ...driver, status: "assigned", assignedReservationId: reservationId }
+        },
+        reservations: {
+          ...nextState.reservations,
+          [reservationId]: { ...nextState.reservations[reservationId], driverId: driverId }
+        }
+      };
+    }
+    case "UNASSIGN_DRIVER": {
+      const { driverId, reservationId } = action;
+      const driver = state.drivers[driverId];
+      const reservation = state.reservations[reservationId];
+      if (!driver || !reservation) {
+        return state;
+      }
+
+      return {
+        ...state,
+        drivers: {
+          ...state.drivers,
+          [driverId]: { ...driver, status: "available", assignedReservationId: undefined }
+        },
+        reservations: {
+          ...state.reservations,
+          [reservationId]: { ...reservation, driverId: undefined }
+        }
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+const App = () => {
+  const [state, dispatch] = useReducer(reducer, undefined, buildInitialState);
+
+  const handleDragEnd = (result: DropResult) => {
+    const { destination, source, draggableId, type } = result;
+    if (!destination) {
+      return;
+    }
+
+    if (
+      destination.droppableId === source.droppableId &&
+      destination.index === source.index
+    ) {
+      return;
+    }
+
+    if (type === "RESERVATION") {
+      const sourceLaneId = source.droppableId.replace("lane-", "");
+      const destinationLaneId = destination.droppableId.replace("lane-", "");
+      dispatch({
+        type: "MOVE_RESERVATION",
+        reservationId: draggableId,
+        sourceLaneId,
+        destinationLaneId,
+        sourceIndex: source.index,
+        destinationIndex: destination.index
+      });
+      return;
+    }
+
+    if (type === "JOB") {
+      const isSourceJobPool = source.droppableId === "jobPool";
+      const isDestinationJobPool = destination.droppableId === "jobPool";
+
+      if (isDestinationJobPool && !isSourceJobPool) {
+        const reservationId = source.droppableId.replace("reservation-job-", "");
+        dispatch({ type: "UNASSIGN_JOB", jobId: draggableId, reservationId });
+        return;
+      }
+
+      if (!isDestinationJobPool) {
+        const reservationId = destination.droppableId.replace("reservation-job-", "");
+        dispatch({ type: "ASSIGN_JOB", jobId: draggableId, reservationId });
+      }
+      return;
+    }
+
+    if (type === "DRIVER") {
+      const isSourceDriverPool = source.droppableId === "driverPool";
+      const isDestinationDriverPool = destination.droppableId === "driverPool";
+
+      if (isDestinationDriverPool && !isSourceDriverPool) {
+        const reservationId = source.droppableId.replace("reservation-driver-", "");
+        dispatch({ type: "UNASSIGN_DRIVER", driverId: draggableId, reservationId });
+        return;
+      }
+
+      if (!isDestinationDriverPool) {
+        const reservationId = destination.droppableId.replace("reservation-driver-", "");
+        dispatch({ type: "ASSIGN_DRIVER", driverId: draggableId, reservationId });
+      }
+    }
+  };
+
+  const availableDrivers = useMemo(
+    () =>
+      state.driverOrder
+        .map((driverId) => state.drivers[driverId])
+        .filter((driver) => driver && driver.status === "available"),
+    [state.driverOrder, state.drivers]
+  );
+
+  const unassignedJobs = useMemo(
+    () =>
+      state.jobOrder
+        .map((jobId) => state.jobs[jobId])
+        .filter((job) => job && !job.reservationId),
+    [state.jobOrder, state.jobs]
+  );
+
+  const lanes = useMemo(
+    () => state.laneOrder.map((laneId) => state.lanes[laneId]).filter(Boolean),
+    [state.laneOrder, state.lanes]
+  );
+
+  const summaryPanel = (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col">
+      <div className="px-4 py-3 border-b border-slate-200">
+        <h2 className="text-lg font-semibold text-slate-700">Dispatch Summary</h2>
+        <p className="text-xs text-slate-500">Snapshot of today&apos;s allocation</p>
+      </div>
+      <div className="flex-1 p-4 space-y-4 text-sm text-slate-600">
+        <div>
+          <p className="text-xs uppercase text-slate-400">Scheduled Jobs</p>
+          <p className="text-2xl font-semibold text-emerald-600">
+            {Object.values(state.jobs).filter((job) => job.status === "scheduled").length}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs uppercase text-slate-400">Unassigned Jobs</p>
+          <p className="text-2xl font-semibold text-amber-500">{unassignedJobs.length}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase text-slate-400">Available Drivers</p>
+          <p className="text-2xl font-semibold text-sky-500">{availableDrivers.length}</p>
+        </div>
+        <div className="space-y-2">
+          <p className="text-xs uppercase text-slate-400">Active Reservations</p>
+          <ul className="space-y-1 text-sm">
+            {lanes.map((lane) => (
+              <li key={lane.id} className="flex justify-between">
+                <span className="font-medium text-slate-700">{lane.name}</span>
+                <span className="text-slate-500">{lane.reservationIds.length} slots</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </div>
   );
-}
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-800">Vehicle Dispatch Board</h1>
+          <p className="text-sm text-slate-500">Assign jobs and drivers across the motor pool timeline.</p>
+        </div>
+      </div>
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <DispatchBoardLayout
+          driverPool={<DriverPool drivers={availableDrivers} />}
+          motorPool={
+            <MotorPoolTimeline
+              lanes={lanes}
+              reservations={state.reservations}
+              jobs={state.jobs}
+              drivers={state.drivers}
+            />
+          }
+          summary={summaryPanel}
+          jobPool={<JobPool jobs={unassignedJobs} />}
+        />
+      </DragDropContext>
+    </div>
+  );
+};
+
 export default App;

--- a/client/src/components/DispatchBoardLayout.tsx
+++ b/client/src/components/DispatchBoardLayout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+type DispatchBoardLayoutProps = {
+  driverPool: ReactNode;
+  motorPool: ReactNode;
+  summary: ReactNode;
+  jobPool: ReactNode;
+};
+
+const DispatchBoardLayout = ({ driverPool, motorPool, summary, jobPool }: DispatchBoardLayoutProps) => {
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[260px_minmax(0,1fr)_280px]">
+        <div className="min-h-[420px]">{driverPool}</div>
+        <div className="min-h-[420px]">{motorPool}</div>
+        <div className="min-h-[420px]">{summary}</div>
+      </div>
+      <div>{jobPool}</div>
+    </div>
+  );
+};
+
+export default DispatchBoardLayout;

--- a/client/src/components/DriverPool.tsx
+++ b/client/src/components/DriverPool.tsx
@@ -1,0 +1,59 @@
+import { Draggable, Droppable } from "react-beautiful-dnd";
+import type { Driver } from "../data/mockData";
+
+type DriverPoolProps = {
+  drivers: Driver[];
+};
+
+const DriverPool = ({ drivers }: DriverPoolProps) => {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col">
+      <div className="px-4 py-3 border-b border-slate-200">
+        <h2 className="text-lg font-semibold text-slate-700">Driver Pool</h2>
+        <p className="text-xs text-slate-500">Drag drivers onto reservations</p>
+      </div>
+      <Droppable droppableId="driverPool" type="DRIVER">
+        {(provided, snapshot) => (
+          <div
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+            className={`flex-1 overflow-y-auto px-4 py-4 space-y-3 transition-colors ${
+              snapshot.isDraggingOver ? "bg-sky-50" : "bg-white"
+            }`}
+          >
+            {drivers.map((driver, index) => (
+              <Draggable draggableId={driver.id} index={index} key={driver.id}>
+                {(dragProvided, dragSnapshot) => (
+                  <div
+                    ref={dragProvided.innerRef}
+                    {...dragProvided.draggableProps}
+                    {...dragProvided.dragHandleProps}
+                    className={`rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm transition ${
+                      dragSnapshot.isDragging ? "ring-2 ring-sky-400" : ""
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-slate-700">{driver.name}</span>
+                      <span className="text-xs font-semibold uppercase text-emerald-600">
+                        {driver.status === "available" ? "Available" : "Assigned"}
+                      </span>
+                    </div>
+                    <p className="text-xs text-slate-500 mt-1">ID: {driver.id}</p>
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {drivers.length === 0 && (
+              <p className="text-sm text-slate-500 text-center py-6">
+                All drivers are currently assigned.
+              </p>
+            )}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </div>
+  );
+};
+
+export default DriverPool;

--- a/client/src/components/JobPool.tsx
+++ b/client/src/components/JobPool.tsx
@@ -1,0 +1,62 @@
+import { Draggable, Droppable } from "react-beautiful-dnd";
+import type { Job } from "../data/mockData";
+
+type JobPoolProps = {
+  jobs: Job[];
+};
+
+const JobPool = ({ jobs }: JobPoolProps) => {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200">
+      <div className="px-4 py-3 border-b border-slate-200 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-700">Job Pool</h2>
+          <p className="text-xs text-slate-500">Drag jobs to assign them to vehicles</p>
+        </div>
+        <span className="text-sm font-medium text-slate-500">{jobs.length} open</span>
+      </div>
+      <Droppable droppableId="jobPool" type="JOB">
+        {(provided, snapshot) => (
+          <div
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+            className={`px-4 py-4 space-y-3 min-h-[180px] transition-colors ${
+              snapshot.isDraggingOver ? "bg-amber-50" : "bg-white"
+            }`}
+          >
+            {jobs.map((job, index) => (
+              <Draggable draggableId={job.id} index={index} key={job.id}>
+                {(dragProvided, dragSnapshot) => (
+                  <div
+                    ref={dragProvided.innerRef}
+                    {...dragProvided.draggableProps}
+                    {...dragProvided.dragHandleProps}
+                    className={`rounded-lg border border-amber-200 bg-white px-3 py-2 shadow-sm transition ${
+                      dragSnapshot.isDragging ? "ring-2 ring-amber-400" : ""
+                    }`}
+                  >
+                    <p className="text-sm font-semibold text-slate-700">{job.title}</p>
+                    <p className="text-xs text-slate-500 mt-1">
+                      {job.pickup} → {job.dropoff}
+                    </p>
+                    <p className="text-xs text-slate-400 mt-1">
+                      Window: {job.windowStart} - {job.windowEnd}
+                    </p>
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {jobs.length === 0 && (
+              <p className="text-sm text-slate-500 text-center py-6">
+                All jobs are currently scheduled.
+              </p>
+            )}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+    </div>
+  );
+};
+
+export default JobPool;

--- a/client/src/components/MotorPoolTimeline.tsx
+++ b/client/src/components/MotorPoolTimeline.tsx
@@ -1,0 +1,162 @@
+import { Draggable, Droppable } from "react-beautiful-dnd";
+import type { Driver, Job, Lane, Reservation } from "../data/mockData";
+
+type MotorPoolTimelineProps = {
+  lanes: Lane[];
+  reservations: Record<string, Reservation>;
+  jobs: Record<string, Job>;
+  drivers: Record<string, Driver>;
+};
+
+const MotorPoolTimeline = ({ lanes, reservations, jobs, drivers }: MotorPoolTimelineProps) => {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col">
+      <div className="px-4 py-3 border-b border-slate-200 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-700">Motor Pool Timeline</h2>
+          <p className="text-xs text-slate-500">Reorder reservations or drop jobs & drivers into cards</p>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {lanes.map((lane) => (
+          <Droppable droppableId={`lane-${lane.id}`} type="RESERVATION" key={lane.id}>
+            {(provided) => (
+              <div
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+                className="bg-slate-50 border border-slate-200 rounded-lg p-4"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-700">{lane.name}</h3>
+                    <p className="text-xs text-slate-500">{lane.reservationIds.length} reservations</p>
+                  </div>
+                </div>
+                <div className="mt-3 space-y-3">
+                  {lane.reservationIds.map((reservationId, index) => {
+                    const reservation = reservations[reservationId];
+                    if (!reservation) {
+                      return null;
+                    }
+                    const assignedJob = reservation.jobId ? jobs[reservation.jobId] : undefined;
+                    const assignedDriver = reservation.driverId ? drivers[reservation.driverId] : undefined;
+
+                    return (
+                      <Draggable draggableId={reservation.id} index={index} key={reservation.id}>
+                        {(dragProvided, dragSnapshot) => (
+                          <div
+                            ref={dragProvided.innerRef}
+                            {...dragProvided.draggableProps}
+                            className={`bg-white border border-slate-200 rounded-lg shadow-sm p-4 transition ${
+                              dragSnapshot.isDragging ? "ring-2 ring-sky-400" : ""
+                            }`}
+                          >
+                            <div className="flex items-center justify-between">
+                              <div>
+                                <p className="text-sm font-semibold text-slate-700">{reservation.vehicleName}</p>
+                                <p className="text-xs text-slate-500">
+                                  {reservation.start} - {reservation.end}
+                                </p>
+                              </div>
+                              <span
+                                className="text-xs uppercase font-semibold text-slate-400"
+                                {...dragProvided.dragHandleProps}
+                              >
+                                Move
+                              </span>
+                            </div>
+                            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+                              <Droppable droppableId={`reservation-job-${reservation.id}`} type="JOB">
+                                {(jobProvided, jobSnapshot) => (
+                                  <div
+                                    ref={jobProvided.innerRef}
+                                    {...jobProvided.droppableProps}
+                                    className={`rounded-md border border-dashed px-3 py-3 min-h-[88px] transition-colors ${
+                                      jobSnapshot.isDraggingOver
+                                        ? "border-amber-400 bg-amber-50"
+                                        : "border-amber-200 bg-amber-50/40"
+                                    }`}
+                                  >
+                                    <p className="text-xs font-semibold text-amber-700 uppercase tracking-wide">
+                                      Job
+                                    </p>
+                                    {assignedJob ? (
+                                      <Draggable draggableId={assignedJob.id} index={0} key={assignedJob.id}>
+                                        {(jobDragProvided, jobDragSnapshot) => (
+                                          <div
+                                            ref={jobDragProvided.innerRef}
+                                            {...jobDragProvided.draggableProps}
+                                            {...jobDragProvided.dragHandleProps}
+                                            className={`mt-2 rounded-md border border-amber-200 bg-white px-2 py-2 text-sm shadow-sm transition ${
+                                              jobDragSnapshot.isDragging ? "ring-2 ring-amber-400" : ""
+                                            }`}
+                                          >
+                                            <p className="font-medium text-slate-700">{assignedJob.title}</p>
+                                            <p className="text-xs text-slate-500">
+                                              {assignedJob.pickup} → {assignedJob.dropoff}
+                                            </p>
+                                          </div>
+                                        )}
+                                      </Draggable>
+                                    ) : (
+                                      <p className="mt-2 text-xs text-slate-500">Drop a job here</p>
+                                    )}
+                                    {jobProvided.placeholder}
+                                  </div>
+                                )}
+                              </Droppable>
+                              <Droppable droppableId={`reservation-driver-${reservation.id}`} type="DRIVER">
+                                {(driverProvided, driverSnapshot) => (
+                                  <div
+                                    ref={driverProvided.innerRef}
+                                    {...driverProvided.droppableProps}
+                                    className={`rounded-md border border-dashed px-3 py-3 min-h-[88px] transition-colors ${
+                                      driverSnapshot.isDraggingOver
+                                        ? "border-sky-400 bg-sky-50"
+                                        : "border-sky-200 bg-sky-50/40"
+                                    }`}
+                                  >
+                                    <p className="text-xs font-semibold text-sky-700 uppercase tracking-wide">
+                                      Driver
+                                    </p>
+                                    {assignedDriver ? (
+                                      <Draggable draggableId={assignedDriver.id} index={0} key={assignedDriver.id}>
+                                        {(driverDragProvided, driverDragSnapshot) => (
+                                          <div
+                                            ref={driverDragProvided.innerRef}
+                                            {...driverDragProvided.draggableProps}
+                                            {...driverDragProvided.dragHandleProps}
+                                            className={`mt-2 rounded-md border border-sky-200 bg-white px-2 py-2 text-sm shadow-sm transition ${
+                                              driverDragSnapshot.isDragging ? "ring-2 ring-sky-400" : ""
+                                            }`}
+                                          >
+                                            <p className="font-medium text-slate-700">{assignedDriver.name}</p>
+                                            <p className="text-xs text-slate-500">ID: {assignedDriver.id}</p>
+                                          </div>
+                                        )}
+                                      </Draggable>
+                                    ) : (
+                                      <p className="mt-2 text-xs text-slate-500">Drop a driver here</p>
+                                    )}
+                                    {driverProvided.placeholder}
+                                  </div>
+                                )}
+                              </Droppable>
+                            </div>
+                          </div>
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {provided.placeholder}
+                </div>
+              </div>
+            )}
+          </Droppable>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MotorPoolTimeline;

--- a/client/src/data/mockData.ts
+++ b/client/src/data/mockData.ts
@@ -1,0 +1,122 @@
+export interface Driver {
+  id: string;
+  name: string;
+  status: "available" | "assigned";
+  assignedReservationId?: string;
+}
+
+export interface Job {
+  id: string;
+  title: string;
+  pickup: string;
+  dropoff: string;
+  windowStart: string;
+  windowEnd: string;
+  status: "unassigned" | "scheduled";
+  reservationId?: string;
+}
+
+export interface Reservation {
+  id: string;
+  laneId: string;
+  vehicleName: string;
+  start: string;
+  end: string;
+  jobId?: string;
+  driverId?: string;
+}
+
+export interface Lane {
+  id: string;
+  name: string;
+  reservationIds: string[];
+}
+
+export const mockDrivers: Driver[] = [
+  { id: "driver-1", name: "Alex Johnson", status: "available" },
+  { id: "driver-2", name: "Robin Singh", status: "assigned", assignedReservationId: "reservation-1" },
+  { id: "driver-3", name: "Jamie Chen", status: "available" },
+  { id: "driver-4", name: "Morgan Lee", status: "assigned", assignedReservationId: "reservation-2" }
+];
+
+export const mockJobs: Job[] = [
+  {
+    id: "job-1",
+    title: "Airport Transfer - Smith",
+    pickup: "Warehouse",
+    dropoff: "Airport",
+    windowStart: "08:00",
+    windowEnd: "09:30",
+    status: "scheduled",
+    reservationId: "reservation-1"
+  },
+  {
+    id: "job-2",
+    title: "Corporate Shuttle",
+    pickup: "HQ",
+    dropoff: "Conference Center",
+    windowStart: "09:00",
+    windowEnd: "12:00",
+    status: "unassigned"
+  },
+  {
+    id: "job-3",
+    title: "Hotel Pick-up - Garcia",
+    pickup: "Hotel Indigo",
+    dropoff: "Main Office",
+    windowStart: "10:30",
+    windowEnd: "11:00",
+    status: "unassigned"
+  },
+  {
+    id: "job-4",
+    title: "Equipment Run",
+    pickup: "Storage Lot",
+    dropoff: "Client Site",
+    windowStart: "13:00",
+    windowEnd: "15:00",
+    status: "scheduled",
+    reservationId: "reservation-2"
+  }
+];
+
+export const mockReservations: Reservation[] = [
+  {
+    id: "reservation-1",
+    laneId: "lane-1",
+    vehicleName: "Sprinter 100",
+    start: "07:45",
+    end: "10:00",
+    jobId: "job-1",
+    driverId: "driver-2"
+  },
+  {
+    id: "reservation-2",
+    laneId: "lane-2",
+    vehicleName: "Transit 55",
+    start: "12:30",
+    end: "16:00",
+    jobId: "job-4",
+    driverId: "driver-4"
+  },
+  {
+    id: "reservation-3",
+    laneId: "lane-1",
+    vehicleName: "Sprinter 100",
+    start: "16:30",
+    end: "18:00"
+  },
+  {
+    id: "reservation-4",
+    laneId: "lane-3",
+    vehicleName: "City Van 12",
+    start: "08:30",
+    end: "11:00"
+  }
+];
+
+export const mockLanes: Lane[] = [
+  { id: "lane-1", name: "Sprinter 100", reservationIds: ["reservation-1", "reservation-3"] },
+  { id: "lane-2", name: "Transit 55", reservationIds: ["reservation-2"] },
+  { id: "lane-3", name: "City Van 12", reservationIds: ["reservation-4"] }
+];

--- a/client/src/lib/reactBeautifulDnd.tsx
+++ b/client/src/lib/reactBeautifulDnd.tsx
@@ -1,0 +1,316 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent as ReactDragEvent,
+  type ReactNode
+} from "react";
+
+export interface DraggableLocation {
+  droppableId: string;
+  index: number;
+}
+
+export interface DropResult {
+  draggableId: string;
+  type: string;
+  source: DraggableLocation;
+  destination: DraggableLocation | null;
+  reason: "DROP" | "CANCEL";
+}
+
+type ActiveDrag = {
+  draggableId: string;
+  type: string;
+  source: DraggableLocation;
+};
+
+type DragContextValue = {
+  activeDrag: ActiveDrag | null;
+  startDrag: (drag: ActiveDrag) => void;
+  completeDrop: (destination: DraggableLocation | null, reason: "DROP" | "CANCEL") => void;
+};
+
+const DragContext = createContext<DragContextValue | null>(null);
+
+export type DragDropContextProps = {
+  onDragEnd: (result: DropResult) => void;
+  children?: ReactNode;
+};
+
+export const DragDropContext = ({ onDragEnd, children }: DragDropContextProps) => {
+  const [activeDrag, setActiveDrag] = useState<ActiveDrag | null>(null);
+  const dropHandledRef = useRef(false);
+
+  const startDrag = useCallback((drag: ActiveDrag) => {
+    dropHandledRef.current = false;
+    setActiveDrag(drag);
+  }, []);
+
+  const completeDrop = useCallback(
+    (destination: DraggableLocation | null, reason: "DROP" | "CANCEL") => {
+      setActiveDrag((current) => {
+        if (!current) {
+          return null;
+        }
+        onDragEnd({
+          draggableId: current.draggableId,
+          type: current.type,
+          source: current.source,
+          destination,
+          reason
+        });
+        dropHandledRef.current = true;
+        return null;
+      });
+    },
+    [onDragEnd]
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      activeDrag,
+      startDrag,
+      completeDrop
+    }),
+    [activeDrag, completeDrop, startDrag]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    if (!dropHandledRef.current && activeDrag) {
+      completeDrop(null, "CANCEL");
+    }
+    dropHandledRef.current = false;
+  }, [activeDrag, completeDrop]);
+
+  return (
+    <DragContext.Provider value={contextValue}>
+      <div onDragEnd={handleDragEnd}>{children}</div>
+    </DragContext.Provider>
+  );
+};
+
+type DroppableContextValue = {
+  droppableId: string;
+  type: string;
+};
+
+const DroppableContext = createContext<DroppableContextValue | null>(null);
+
+export type DroppableStateSnapshot = {
+  isDraggingOver: boolean;
+};
+
+export type DroppableProvided = {
+  innerRef: (element: HTMLElement | null) => void;
+  droppableProps: {
+    onDragOver: (event: ReactDragEvent) => void;
+    onDragEnter: (event: ReactDragEvent) => void;
+    onDragLeave: (event: ReactDragEvent) => void;
+    onDrop: (event: ReactDragEvent) => void;
+    "data-dnd-droppable": string;
+  };
+  placeholder: ReactNode;
+};
+
+export type DroppableProps = {
+  droppableId: string;
+  type?: string;
+  children: (provided: DroppableProvided, snapshot: DroppableStateSnapshot) => ReactNode;
+};
+
+export const Droppable = ({ droppableId, type = "DEFAULT", children }: DroppableProps) => {
+  const dragContext = useContext(DragContext);
+  const containerRef = useRef<HTMLElement | null>(null);
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+
+  const setRef = useCallback(
+    (element: HTMLElement | null) => {
+      containerRef.current = element;
+    },
+    []
+  );
+
+  const computeIndex = useCallback(
+    (event: ReactDragEvent): number => {
+      const container = containerRef.current;
+      if (!container) {
+        return 0;
+      }
+      const target = (event.target as HTMLElement | null)?.closest<HTMLElement>("[data-dnd-draggable]");
+      if (target && container.contains(target)) {
+        const indexAttr = target.getAttribute("data-dnd-index");
+        const parsed = indexAttr ? Number.parseInt(indexAttr, 10) : Number.NaN;
+        if (!Number.isNaN(parsed)) {
+          return parsed;
+        }
+      }
+      return container.querySelectorAll("[data-dnd-draggable]").length;
+    },
+    []
+  );
+
+  const handleDragOver = useCallback(
+    (event: ReactDragEvent) => {
+      if (!dragContext?.activeDrag) {
+        return;
+      }
+      if (dragContext.activeDrag.type !== type) {
+        return;
+      }
+      event.preventDefault();
+    },
+    [dragContext, type]
+  );
+
+  const handleDragEnter = useCallback(
+    (event: ReactDragEvent) => {
+      if (!dragContext?.activeDrag) {
+        return;
+      }
+      if (dragContext.activeDrag.type !== type) {
+        return;
+      }
+      event.preventDefault();
+      setIsDraggingOver(true);
+    },
+    [dragContext, type]
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setIsDraggingOver(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: ReactDragEvent) => {
+      if (!dragContext?.activeDrag) {
+        return;
+      }
+      if (dragContext.activeDrag.type !== type) {
+        return;
+      }
+      event.preventDefault();
+      const index = computeIndex(event);
+      dragContext.completeDrop({ droppableId, index }, "DROP");
+      setIsDraggingOver(false);
+    },
+    [computeIndex, dragContext, droppableId, type]
+  );
+
+  const provided: DroppableProvided = useMemo(
+    () => ({
+      innerRef: setRef,
+      droppableProps: {
+        onDragOver: handleDragOver,
+        onDragEnter: handleDragEnter,
+        onDragLeave: handleDragLeave,
+        onDrop: handleDrop,
+        "data-dnd-droppable": droppableId
+      },
+      placeholder: null
+    }),
+    [droppableId, handleDragEnter, handleDragLeave, handleDragOver, handleDrop, setRef]
+  );
+
+  const snapshot: DroppableStateSnapshot = useMemo(
+    () => ({ isDraggingOver }),
+    [isDraggingOver]
+  );
+
+  const contextValue = useMemo(
+    () => ({ droppableId, type }),
+    [droppableId, type]
+  );
+
+  return (
+    <DroppableContext.Provider value={contextValue}>
+      {children(provided, snapshot)}
+    </DroppableContext.Provider>
+  );
+};
+
+export type DraggableStateSnapshot = {
+  isDragging: boolean;
+};
+
+export type DraggableProvided = {
+  innerRef: (element: HTMLElement | null) => void;
+  draggableProps: {
+    draggable: boolean;
+    onDragStart: (event: ReactDragEvent) => void;
+    onDragEnd: (event: ReactDragEvent) => void;
+    "data-dnd-draggable": string;
+    "data-dnd-index": number;
+  };
+  dragHandleProps: {
+    onDragStart: (event: ReactDragEvent) => void;
+  };
+};
+
+export type DraggableProps = {
+  draggableId: string;
+  index: number;
+  children: (provided: DraggableProvided, snapshot: DraggableStateSnapshot) => ReactNode;
+};
+
+export const Draggable = ({ draggableId, index, children }: DraggableProps) => {
+  const dragContext = useContext(DragContext);
+  const droppable = useContext(DroppableContext);
+  const [isDragging, setIsDragging] = useState(false);
+  const nodeRef = useRef<HTMLElement | null>(null);
+
+  const setRef = useCallback((element: HTMLElement | null) => {
+    nodeRef.current = element;
+  }, []);
+
+  const handleDragStart = useCallback(
+    (event: ReactDragEvent) => {
+      if (!dragContext || !droppable) {
+        return;
+      }
+      dragContext.startDrag({
+        draggableId,
+        type: droppable.type,
+        source: { droppableId: droppable.droppableId, index }
+      });
+      event.dataTransfer.effectAllowed = "move";
+      setIsDragging(true);
+    },
+    [dragContext, draggableId, droppable, index]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: ReactDragEvent) => {
+      event.preventDefault();
+      setIsDragging(false);
+    },
+    []
+  );
+
+  const provided = useMemo<DraggableProvided>(
+    () => ({
+      innerRef: setRef,
+      draggableProps: {
+        draggable: true,
+        onDragStart: handleDragStart,
+        onDragEnd: handleDragEnd,
+        "data-dnd-draggable": draggableId,
+        "data-dnd-index": index
+      },
+      dragHandleProps: {
+        onDragStart: handleDragStart
+      }
+    }),
+    [draggableId, handleDragEnd, handleDragStart, index, setRef]
+  );
+
+  const snapshot = useMemo<DraggableStateSnapshot>(
+    () => ({ isDragging }),
+    [isDragging]
+  );
+
+  return <>{children(provided, snapshot)}</>;
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -13,7 +13,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "react-beautiful-dnd": ["./src/lib/reactBeautifulDnd"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import path from "path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      "react-beautiful-dnd": path.resolve(__dirname, "src/lib/reactBeautifulDnd.tsx")
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- replace the mock screen with a reducer-driven dispatch board composed of dedicated driver, timeline, and job pool components
- seed the board with mock driver, job, lane, and reservation data to visualise the pools
- introduce a local drag-and-drop implementation and wiring so jobs, drivers, and reservations can be rearranged within the board

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e12a9ee4908322a0e47393c0ba8158