### PR TITLE
feat: refresh booking and dispatch UI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@vitejs/plugin-react": "^4.2.0",
+    "@tailwindcss/forms": "^0.5.7",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,531 @@
-// client/src/App.tsx
-import VehicleDispatchBoardMock from "./components/VehicleDispatchBoardMock";
+import { useEffect, useMemo, useState } from "react";
+import Navbar from "./components/Navbar";
+import Card, { CardContent, CardFooter, CardHeader } from "./components/Card";
+import StatusBadge, { STATUS_LABELS, type DispatchStatus } from "./components/StatusBadge";
+import type { Driver, Job, Reservation } from "./data/mockData";
+import { mockDrivers, mockJobs, mockReservations } from "./data/mockData";
 
-export default function App() {
+type Tab = "home" | "booking" | "dispatch";
+
+type BookingFormData = {
+  clientName: string;
+  contact: string;
+  pickup: string;
+  dropoff: string;
+  date: string;
+  time: string;
+  passengers: string;
+  vehicleType: string;
+  notes: string;
+};
+
+type ToastState = {
+  message: string;
+  tone: "success" | "error";
+} | null;
+
+type DispatchRow = {
+  id: string;
+  reservation: Reservation | null;
+  job: Job | null;
+  driverId: string;
+  status: DispatchStatus;
+};
+
+const statusOptions: DispatchStatus[] = ["queued", "assigned", "on-route", "completed", "canceled"];
+
+const bookingInitialState: BookingFormData = {
+  clientName: "",
+  contact: "",
+  pickup: "",
+  dropoff: "",
+  date: "",
+  time: "",
+  passengers: "1",
+  vehicleType: "",
+  notes: ""
+};
+
+const requiredBookingFields: Array<keyof BookingFormData> = [
+  "clientName",
+  "pickup",
+  "dropoff",
+  "date",
+  "time"
+];
+
+const buildInitialDispatchRows = (): DispatchRow[] => {
+  const jobMap = new Map(mockJobs.map((job) => [job.id, job]));
+  const rows: DispatchRow[] = mockReservations.map((reservation, index) => {
+    const job = reservation.jobId ? jobMap.get(reservation.jobId) ?? null : null;
+    let status: DispatchStatus;
+    if (!job) {
+      status = "queued";
+    } else if (!reservation.driverId) {
+      status = "assigned";
+    } else {
+      status = index % 2 === 0 ? "on-route" : "completed";
+    }
+    return {
+      id: reservation.id,
+      reservation,
+      job,
+      driverId: reservation.driverId ?? "",
+      status
+    };
+  });
+
+  const reservationJobIds = new Set(mockReservations.map((reservation) => reservation.jobId).filter(Boolean) as string[]);
+  const openJobs = mockJobs
+    .filter((job) => !reservationJobIds.has(job.id))
+    .map((job, index) => ({
+      id: `job-${job.id}`,
+      reservation: null,
+      job,
+      driverId: "",
+      status: (index === 0 ? "queued" : "canceled") as DispatchStatus
+    }));
+
+  return [...rows, ...openJobs];
+};
+
+const formatWindow = (row: DispatchRow) => {
+  if (row.reservation) {
+    return `${row.reservation.start} – ${row.reservation.end}`;
+  }
+  if (row.job) {
+    return `${row.job.windowStart} – ${row.job.windowEnd}`;
+  }
+  return "—";
+};
+
+const App = () => {
+  const [activeTab, setActiveTab] = useState<Tab>("home");
+  const [formData, setFormData] = useState<BookingFormData>(bookingInitialState);
+  const [formErrors, setFormErrors] = useState<Partial<Record<keyof BookingFormData, string>>>({});
+  const [touched, setTouched] = useState<Record<keyof BookingFormData, boolean>>({
+    clientName: false,
+    contact: false,
+    pickup: false,
+    dropoff: false,
+    date: false,
+    time: false,
+    passengers: false,
+    vehicleType: false,
+    notes: false
+  });
+  const [submitted, setSubmitted] = useState(false);
+  const [toast, setToast] = useState<ToastState>(null);
+  const [dispatchRows, setDispatchRows] = useState<DispatchRow[]>(() => buildInitialDispatchRows());
+
+  const driverMap = useMemo(() => new Map<string, Driver>(mockDrivers.map((driver) => [driver.id, driver])), []);
+
+  useEffect(() => {
+    if (!toast) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setToast(null), 3200);
+    return () => window.clearTimeout(timeout);
+  }, [toast]);
+
+  const handleNavigate = (tab: Tab) => {
+    setActiveTab(tab);
+  };
+
+  const handleFieldChange = (field: keyof BookingFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (submitted) {
+      validateForm({ ...formData, [field]: value });
+    }
+  };
+
+  const handleBlur = (field: keyof BookingFormData) => {
+    setTouched((prev) => ({ ...prev, [field]: true }));
+  };
+
+  const validateForm = (data: BookingFormData) => {
+    const nextErrors: Partial<Record<keyof BookingFormData, string>> = {};
+    requiredBookingFields.forEach((field) => {
+      if (!data[field]?.trim()) {
+        nextErrors[field] = "この項目は必須です";
+      }
+    });
+    setFormErrors(nextErrors);
+    return nextErrors;
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitted(true);
+    const errors = validateForm(formData);
+    if (Object.keys(errors).length > 0) {
+      setToast({ message: "必須項目を確認してください。", tone: "error" });
+      return;
+    }
+
+    setToast({ message: "予約リクエストを登録しました。", tone: "success" });
+    setFormData(bookingInitialState);
+    setTouched({
+      clientName: false,
+      contact: false,
+      pickup: false,
+      dropoff: false,
+      date: false,
+      time: false,
+      passengers: false,
+      vehicleType: false,
+      notes: false
+    });
+    setSubmitted(false);
+    setFormErrors({});
+  };
+
+  const handleStatusChange = (rowId: string, status: DispatchStatus) => {
+    setDispatchRows((prev) => prev.map((row) => (row.id === rowId ? { ...row, status } : row)));
+  };
+
+  const handleDriverChange = (rowId: string, driverId: string) => {
+    setDispatchRows((prev) => prev.map((row) => (row.id === rowId ? { ...row, driverId } : row)));
+  };
+
+  const renderHome = () => (
+    <section className="space-y-6 text-center">
+      <h1 className="text-2xl font-semibold text-slate-900">車両配車と予約管理をシンプルに</h1>
+      <p className="mx-auto max-w-3xl text-sm text-slate-600 sm:text-base">
+        予約受付からドライバーの割り当てまで、日々のオペレーションをスムーズに行えるワークスペースです。
+        リアルタイムの状況確認と素早いアクションで、チームの連携を高めましょう。
+      </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <button
+          type="button"
+          onClick={() => handleNavigate("booking")}
+          className="w-full rounded-xl bg-slate-900 px-8 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 sm:w-auto"
+        >
+          Bookingを作成する
+        </button>
+        <button
+          type="button"
+          onClick={() => handleNavigate("dispatch")}
+          className="w-full rounded-xl border border-slate-300 bg-white px-8 py-3 text-base font-semibold text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 sm:w-auto"
+        >
+          Dispatchを確認する
+        </button>
+      </div>
+    </section>
+  );
+
+  const renderBooking = () => (
+    <Card>
+      <CardHeader className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-900">新規Booking</h2>
+        <p className="text-sm text-slate-500">必須項目を入力して配車担当者に共有します。</p>
+      </CardHeader>
+      <form onSubmit={handleSubmit} noValidate>
+        <CardContent className="space-y-5">
+          {submitted && Object.keys(formErrors).length > 0 && (
+            <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-600">
+              入力内容をご確認ください。必須項目が不足しています。
+            </div>
+          )}
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+            <div className="space-y-1">
+              <label htmlFor="clientName" className="text-sm font-medium text-slate-700">
+                依頼主<span className="ml-1 text-rose-500">*</span>
+              </label>
+              <input
+                id="clientName"
+                name="clientName"
+                value={formData.clientName}
+                onChange={(event) => handleFieldChange("clientName", event.target.value)}
+                onBlur={() => handleBlur("clientName")}
+                className={`mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900 ${
+                  formErrors.clientName && (touched.clientName || submitted) ? "border-rose-400 focus:border-rose-500 focus:ring-rose-500" : ""
+                }`}
+                placeholder="例）ABC商事 山田様"
+              />
+              {formErrors.clientName && (touched.clientName || submitted) && (
+                <p className="text-xs text-rose-500">{formErrors.clientName}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="contact" className="text-sm font-medium text-slate-700">
+                連絡先
+              </label>
+              <input
+                id="contact"
+                name="contact"
+                value={formData.contact}
+                onChange={(event) => handleFieldChange("contact", event.target.value)}
+                onBlur={() => handleBlur("contact")}
+                className="mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900"
+                placeholder="メールまたは電話番号"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="pickup" className="text-sm font-medium text-slate-700">
+                ピックアップ地点<span className="ml-1 text-rose-500">*</span>
+              </label>
+              <input
+                id="pickup"
+                name="pickup"
+                value={formData.pickup}
+                onChange={(event) => handleFieldChange("pickup", event.target.value)}
+                onBlur={() => handleBlur("pickup")}
+                className={`mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900 ${
+                  formErrors.pickup && (touched.pickup || submitted) ? "border-rose-400 focus:border-rose-500 focus:ring-rose-500" : ""
+                }`}
+                placeholder="出発地を入力"
+              />
+              {formErrors.pickup && (touched.pickup || submitted) && (
+                <p className="text-xs text-rose-500">{formErrors.pickup}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="dropoff" className="text-sm font-medium text-slate-700">
+                ドロップオフ地点<span className="ml-1 text-rose-500">*</span>
+              </label>
+              <input
+                id="dropoff"
+                name="dropoff"
+                value={formData.dropoff}
+                onChange={(event) => handleFieldChange("dropoff", event.target.value)}
+                onBlur={() => handleBlur("dropoff")}
+                className={`mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900 ${
+                  formErrors.dropoff && (touched.dropoff || submitted) ? "border-rose-400 focus:border-rose-500 focus:ring-rose-500" : ""
+                }`}
+                placeholder="到着地を入力"
+              />
+              {formErrors.dropoff && (touched.dropoff || submitted) && (
+                <p className="text-xs text-rose-500">{formErrors.dropoff}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="date" className="text-sm font-medium text-slate-700">
+                日付<span className="ml-1 text-rose-500">*</span>
+              </label>
+              <input
+                type="date"
+                id="date"
+                name="date"
+                value={formData.date}
+                onChange={(event) => handleFieldChange("date", event.target.value)}
+                onBlur={() => handleBlur("date")}
+                className={`mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900 ${
+                  formErrors.date && (touched.date || submitted) ? "border-rose-400 focus:border-rose-500 focus:ring-rose-500" : ""
+                }`}
+              />
+              {formErrors.date && (touched.date || submitted) && (
+                <p className="text-xs text-rose-500">{formErrors.date}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="time" className="text-sm font-medium text-slate-700">
+                時刻<span className="ml-1 text-rose-500">*</span>
+              </label>
+              <input
+                type="time"
+                id="time"
+                name="time"
+                value={formData.time}
+                onChange={(event) => handleFieldChange("time", event.target.value)}
+                onBlur={() => handleBlur("time")}
+                className={`mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900 ${
+                  formErrors.time && (touched.time || submitted) ? "border-rose-400 focus:border-rose-500 focus:ring-rose-500" : ""
+                }`}
+              />
+              {formErrors.time && (touched.time || submitted) && (
+                <p className="text-xs text-rose-500">{formErrors.time}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="passengers" className="text-sm font-medium text-slate-700">
+                乗車人数
+              </label>
+              <input
+                type="number"
+                min={1}
+                id="passengers"
+                name="passengers"
+                value={formData.passengers}
+                onChange={(event) => handleFieldChange("passengers", event.target.value)}
+                onBlur={() => handleBlur("passengers")}
+                className="mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="vehicleType" className="text-sm font-medium text-slate-700">
+                希望車種
+              </label>
+              <select
+                id="vehicleType"
+                name="vehicleType"
+                value={formData.vehicleType}
+                onChange={(event) => handleFieldChange("vehicleType", event.target.value)}
+                onBlur={() => handleBlur("vehicleType")}
+                className="mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900"
+              >
+                <option value="">指定なし</option>
+                <option value="sedan">セダン</option>
+                <option value="van">ワゴン／バン</option>
+                <option value="luxury">ハイグレード</option>
+              </select>
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label htmlFor="notes" className="text-sm font-medium text-slate-700">
+                備考
+              </label>
+              <textarea
+                id="notes"
+                name="notes"
+                rows={3}
+                value={formData.notes}
+                onChange={(event) => handleFieldChange("notes", event.target.value)}
+                onBlur={() => handleBlur("notes")}
+                className="mt-1 block w-full rounded-xl border-slate-300 shadow-sm focus:border-slate-900 focus:ring-slate-900"
+                placeholder="到着時の注意点やゲスト情報など"
+              />
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="submit"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-slate-900 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 sm:w-auto"
+          >
+            送信する
+          </button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+
+  const renderDispatch = () => (
+    <Card>
+      <CardHeader className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-900">Dispatch状況</h2>
+        <p className="text-sm text-slate-500">予約と車両の割り当て状況を確認できます。</p>
+      </CardHeader>
+      <CardContent className="px-0">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                  予約／ジョブ
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                  スケジュール
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                  ドライバー
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                  ステータス
+                </th>
+                <th scope="col" className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-slate-500">
+                  …
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {dispatchRows.map((row) => {
+                const driverName = row.driverId ? driverMap.get(row.driverId)?.name : null;
+                const vehicleLabel = row.reservation?.vehicleName;
+                const secondaryLine = row.job
+                  ? `${row.job.pickup} → ${row.job.dropoff}`
+                  : vehicleLabel
+                  ? `Vehicle: ${vehicleLabel}`
+                  : "Unassigned";
+
+                return (
+                  <tr key={row.id} className="transition-colors hover:bg-slate-50">
+                    <td className="whitespace-nowrap px-4 py-3 align-top">
+                      <div className="font-medium text-slate-800">
+                        {row.job?.title ?? (vehicleLabel ? `Open Slot - ${vehicleLabel}` : "Pending Assignment")}
+                      </div>
+                      <div className="mt-1 text-xs text-slate-500">{secondaryLine}</div>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 align-top text-slate-600">{formatWindow(row)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 align-top text-slate-600">
+                      {driverName ? (
+                        driverName
+                      ) : (
+                        <span className="text-amber-600">未割当</span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 align-top">
+                      <StatusBadge status={row.status} />
+                    </td>
+                    <td className="px-4 py-3 align-top">
+                      <div className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white px-3 py-3 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
+                        <div className="flex flex-col gap-1 text-xs text-slate-500">
+                          <span className="font-medium">Status</span>
+                          <select
+                            id={`status-${row.id}`}
+                            value={row.status}
+                            onChange={(event) => handleStatusChange(row.id, event.target.value as DispatchStatus)}
+                            className="w-full rounded-lg border-slate-300 text-sm focus:border-slate-900 focus:ring-slate-900 sm:w-36"
+                          >
+                            {statusOptions.map((option) => (
+                              <option key={option} value={option}>
+                                {STATUS_LABELS[option]}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="flex flex-col gap-1 text-xs text-slate-500">
+                          <span className="font-medium">Driver</span>
+                          <select
+                            id={`driver-${row.id}`}
+                            value={row.driverId}
+                            onChange={(event) => handleDriverChange(row.id, event.target.value)}
+                            className="w-full rounded-lg border-slate-300 text-sm focus:border-slate-900 focus:ring-slate-900 sm:w-40"
+                          >
+                            <option value="">未割当</option>
+                            {mockDrivers.map((driver) => (
+                              <option key={driver.id} value={driver.id}>
+                                {driver.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
   return (
-    <div className="h-screen">
-      <VehicleDispatchBoardMock />
+    <div className="min-h-screen pb-16">
+      <Navbar activeTab={activeTab} onNavigate={handleNavigate} />
+      <main className="pt-24">
+        <div className="mx-auto max-w-5xl space-y-8 px-6">
+          {activeTab === "home" && renderHome()}
+          {activeTab === "booking" && renderBooking()}
+          {activeTab === "dispatch" && renderDispatch()}
+        </div>
+      </main>
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`fixed bottom-6 right-6 z-50 rounded-xl border px-4 py-3 text-sm shadow-lg ${
+            toast.tone === "success"
+              ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+              : "border-rose-200 bg-rose-50 text-rose-600"
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
     </div>
   );
-}
+};
+
+export default App;

--- a/client/src/components/Card.tsx
+++ b/client/src/components/Card.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+type CardProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+type CardSectionProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+const merge = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(" ");
+
+export function Card({ children, className }: CardProps) {
+  return (
+    <div className={merge("rounded-2xl border border-slate-200 bg-white shadow-sm", className)}>
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ children, className }: CardSectionProps) {
+  return <div className={merge("px-6 py-5 border-b border-slate-200", className)}>{children}</div>;
+}
+
+export function CardContent({ children, className }: CardSectionProps) {
+  return <div className={merge("px-6 py-5", className)}>{children}</div>;
+}
+
+export function CardFooter({ children, className }: CardSectionProps) {
+  return <div className={merge("px-6 py-5 border-t border-slate-200", className)}>{children}</div>;
+}
+
+export default Card;

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,0 +1,61 @@
+import type { MouseEventHandler } from "react";
+
+type Tab = "home" | "booking" | "dispatch";
+
+type NavbarProps = {
+  activeTab: Tab;
+  onNavigate: (tab: Tab) => void;
+};
+
+const tabs: Array<{ id: Tab; label: string }> = [
+  { id: "booking", label: "Booking" },
+  { id: "dispatch", label: "Dispatch" }
+];
+
+const merge = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(" ");
+
+const handleClick = (
+  tab: Tab,
+  onNavigate: (tab: Tab) => void
+): MouseEventHandler<HTMLButtonElement> =>
+  (event) => {
+    event.preventDefault();
+    onNavigate(tab);
+  };
+
+const Navbar = ({ activeTab, onNavigate }: NavbarProps) => {
+  return (
+    <header className="fixed inset-x-0 top-0 z-40 border-b border-slate-200 bg-white/80 backdrop-blur">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <button
+          type="button"
+          onClick={handleClick("home", onNavigate)}
+          className="text-lg font-semibold text-slate-800 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+        >
+          Hire Dispatch Desk
+        </button>
+        <nav className="flex items-center gap-2">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={handleClick(tab.id, onNavigate)}
+              className={merge(
+                "rounded-full px-4 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+                activeTab === tab.id
+                  ? "bg-slate-900 text-white focus-visible:outline-slate-900"
+                  : "text-slate-600 hover:text-slate-900 focus-visible:outline-slate-400"
+              )}
+              aria-current={activeTab === tab.id ? "page" : undefined}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/client/src/components/StatusBadge.tsx
+++ b/client/src/components/StatusBadge.tsx
@@ -1,0 +1,41 @@
+export type DispatchStatus = "queued" | "assigned" | "on-route" | "completed" | "canceled";
+
+type StatusBadgeProps = {
+  status: DispatchStatus;
+  className?: string;
+};
+
+export const STATUS_LABELS: Record<DispatchStatus, string> = {
+  queued: "Queued",
+  assigned: "Assigned",
+  "on-route": "On Route",
+  completed: "Completed",
+  canceled: "Canceled"
+};
+
+const STYLES: Record<DispatchStatus, string> = {
+  queued: "bg-slate-100 text-slate-700 border-slate-200",
+  assigned: "bg-sky-100 text-sky-700 border-sky-200",
+  "on-route": "bg-amber-100 text-amber-700 border-amber-200",
+  completed: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  canceled: "bg-rose-100 text-rose-700 border-rose-200"
+};
+
+const merge = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(" ");
+
+const StatusBadge = ({ status, className }: StatusBadgeProps) => {
+  return (
+    <span
+      className={merge(
+        "inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium",
+        STYLES[status],
+        className
+      )}
+    >
+      {STATUS_LABELS[status]}
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/client/src/components/VehicleDispatchBoardMock.tsx
+++ b/client/src/components/VehicleDispatchBoardMock.tsx
@@ -163,7 +163,7 @@ export default function VehicleDispatchBoardMock() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerItem, setDrawerItem] = useState<any>(null);
   const [selected, setSelected] = useState<{ type: "booking" | "duty"; id: number | string } | null>(null);
-  const [bookings, setBookings] = useState(BOOKINGS);
+  const [bookings, setBookings] = useState<any[]>(BOOKINGS);
   const [appDuties, setAppDuties] = useState(APP_DUTIES_INIT);
   const [jobPool, setJobPool] = useState(UNASSIGNED_JOBS);
   const [flashUnassignId, setFlashUnassignId] = useState<number | null>(null);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -10,4 +10,5 @@
 body {
   margin: 0;
   min-height: 100vh;
+  @apply bg-slate-50 text-slate-900 antialiased;
 }

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -4,5 +4,5 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/forms')],
 }


### PR DESCRIPTION
## Summary
- add a fixed top navigation bar and reusable card + status badge components
- redesign the booking flow with responsive validation, card layout, and toast feedback
- restyle the dispatch overview into a carded table with grouped action controls and hover states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e2bfae08e483229d8a87ca147f17dd