### PR TITLE
Add responsive driver ledger section

### DIFF
--- a/client/src/components/VehicleDispatchBoardMock.css
+++ b/client/src/components/VehicleDispatchBoardMock.css
@@ -12,3 +12,174 @@
 .flash-border {
   animation: flashBorder 0.3s ease-in-out 5;
 }
+
+.driver-ledger-section {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e2e8f0;
+  position: relative;
+  scroll-margin-top: 96px;
+}
+
+.driver-ledger-section::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 48px;
+  height: 3px;
+  background: linear-gradient(90deg, #38bdf8, #6366f1);
+  border-radius: 9999px;
+}
+
+.driver-ledger-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: #475569;
+  max-width: 60ch;
+}
+
+.driver-ledger-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.driver-ledger-grid {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.driver-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 160px;
+}
+
+.driver-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.driver-card__name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.driver-card__code {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background: #f1f5f9;
+  color: #475569;
+  margin-top: 0.35rem;
+}
+
+.driver-card__count {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  background: #e2e8f0;
+  color: #475569;
+  white-space: nowrap;
+}
+
+.driver-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.driver-card__row {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 0.5rem;
+  align-items: flex-start;
+  font-size: 0.85rem;
+}
+
+.driver-card__label {
+  font-weight: 600;
+  color: #334155;
+}
+
+.driver-card__value {
+  color: #0f172a;
+}
+
+.driver-card__assignments {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.driver-card__assignment {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.driver-card__time {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #0369a1;
+}
+
+.driver-card__title {
+  font-size: 0.85rem;
+  color: #1f2937;
+}
+
+.driver-card__empty {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.driver-card__highlight {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #1d4ed8;
+}
+
+@media (max-width: 640px) {
+  .driver-ledger-section {
+    padding-top: 1.25rem;
+    scroll-margin-top: 80px;
+  }
+
+  .driver-card {
+    padding: 0.85rem 1rem;
+  }
+
+  .driver-card__row {
+    grid-template-columns: 1fr;
+  }
+
+  .driver-card__label {
+    font-size: 0.8rem;
+  }
+}

--- a/client/src/components/VehicleDispatchBoardMock.tsx
+++ b/client/src/components/VehicleDispatchBoardMock.tsx
@@ -369,6 +369,19 @@ export default function VehicleDispatchBoardMock() {
   const [viewDate, setViewDate] = useState("2025-10-03");
   const dateInputRef = useRef<HTMLInputElement | null>(null);
   const [now, setNow] = useState(() => new Date());
+  const driverSummaries = useMemo(
+    () =>
+      DRIVERS.map((driver) => {
+        const todaysAssignments = bookings
+          .filter((b) => b.driverId === driver.id)
+          .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+        return {
+          driver,
+          assignments: todaysAssignments
+        };
+      }),
+    [bookings]
+  );
 
   const viewDateObj = useMemo(() => new Date(`${viewDate}T00:00:00+09:00`), [viewDate]);
   const viewDateDisplay = useMemo(() => {
@@ -1051,6 +1064,55 @@ export default function VehicleDispatchBoardMock() {
             車両台帳
           </a>
         </div>
+
+        <section id="driver-ledger" className="driver-ledger-section">
+          <div className="driver-ledger-header">
+            <h2>ドライバー台帳</h2>
+            <p>
+              現在の割当状況と稼働回数を確認できます。各カードは当日の予約情報からリアルタイムに集計され、スクロール後もアンカー位置がわかるようにマージンを調整しています。
+            </p>
+          </div>
+          <div className="driver-ledger-grid">
+            {driverSummaries.map(({ driver, assignments }) => (
+              <article key={driver.id} className="driver-card">
+                <header className="driver-card__header">
+                  <div>
+                    <div className="driver-card__name">{driver.name}</div>
+                    <div className="driver-card__code">{driver.code}</div>
+                  </div>
+                  <div className="driver-card__count">本日 {assignments.length} 件</div>
+                </header>
+                <dl className="driver-card__meta">
+                  <div className="driver-card__row">
+                    <dt className="driver-card__label">割当状況</dt>
+                    <dd className="driver-card__value">
+                      {assignments.length === 0 ? (
+                        <span className="driver-card__empty">未割当</span>
+                      ) : (
+                        <ul className="driver-card__assignments">
+                          {assignments.map((assignment) => (
+                            <li key={assignment.id} className="driver-card__assignment">
+                              <span className="driver-card__time">
+                                {fmt(assignment.start)} - {fmt(assignment.end)}
+                              </span>
+                              <span className="driver-card__title">{assignment.title}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </dd>
+                  </div>
+                  <div className="driver-card__row">
+                    <dt className="driver-card__label">稼働回数</dt>
+                    <dd className="driver-card__value">
+                      <span className="driver-card__highlight">{driver.extUsed}</span> 回
+                    </dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        </section>
 
         {drawerOpen && (
           <Drawer isMobile={isMobile} onClose={closeDrawer}>


### PR DESCRIPTION
## Summary
- add a driver ledger section that aggregates assignments and extUsed metrics from the existing state
- style the ledger with responsive cards and anchor spacing so the jump link lands cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e338d982ec8322b442d4f2400b90f9