### PR TITLE
Fix overnight navigation buttons sticking to timeline

### DIFF
--- a/client/src/components/VehicleDispatchBoardMock.tsx
+++ b/client/src/components/VehicleDispatchBoardMock.tsx
@@ -1193,12 +1193,12 @@ export default function VehicleDispatchBoardMock() {
             <ResizeHandle value={driverWidth} setValue={setDriverWidth} min={DRIVER_POOL_WIDTH_MIN} max={DRIVER_POOL_WIDTH_MAX} side="right" />
           </div>
 
-          <div ref={centerRef} className={`flex-1 bg-white rounded-2xl shadow p-3 relative overflow-y-auto ${fullView ? "overflow-x-hidden" : "overflow-x-auto"}`}>
+          <div className="relative flex-1">
             {hasPrevOvernight ? (
               <button
                 type="button"
                 onClick={() => shiftViewDate(-1)}
-                className="absolute left-2 top-1/2 z-20 flex h-28 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-slate-300 bg-white/90 text-sm font-semibold text-slate-700 shadow hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                className="pointer-events-auto absolute left-2 top-1/2 z-20 flex h-28 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-slate-300 bg-white/90 text-sm font-semibold text-slate-700 shadow hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
                 style={{ writingMode: "vertical-rl", textOrientation: "upright" }}
                 aria-label="前日の夜間予約へ移動"
                 title="前日の夜間予約へ移動"
@@ -1221,7 +1221,7 @@ export default function VehicleDispatchBoardMock() {
               <button
                 type="button"
                 onClick={() => shiftViewDate(1)}
-                className="absolute right-2 top-1/2 z-20 flex h-28 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-slate-300 bg-white/90 text-sm font-semibold text-slate-700 shadow hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                className="pointer-events-auto absolute right-2 top-1/2 z-20 flex h-28 w-8 -translate-y-1/2 items-center justify-center rounded-full border border-slate-300 bg-white/90 text-sm font-semibold text-slate-700 shadow hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
                 style={{ writingMode: "vertical-rl", textOrientation: "upright" }}
                 aria-label="翌日の夜間予約へ移動"
                 title="翌日の夜間予約へ移動"
@@ -1240,98 +1240,105 @@ export default function VehicleDispatchBoardMock() {
                 <span>翌</span>
               </button>
             ) : null}
-            <div className="flex items-center justify-between mb-2 sticky left-0 top-0 z-10 bg-white pr-2">
-              <h2 className="font-medium">モータープール</h2>
-              <span className="text-xs text-slate-500">00:00〜24:00（{pxPerMin.toFixed(2)} px/min）</span>
-            </div>
+            <div
+              ref={centerRef}
+              className={`bg-white rounded-2xl shadow p-3 relative h-full overflow-y-auto ${fullView ? "overflow-x-hidden" : "overflow-x-auto"}`}
+            >
+              <div className="flex items-center justify-between mb-2 sticky left-0 top-0 z-10 bg-white pr-2">
+                <h2 className="font-medium">モータープール</h2>
+                <span className="text-xs text-slate-500">00:00〜24:00（{pxPerMin.toFixed(2)} px/min）</span>
+              </div>
 
-            <div className="relative" style={{ width: CONTENT_WIDTH }}>
-              <GridOverlay hourPx={60 * pxPerMin} />
-              {currentTimePosition.visible ? (
-                <div
-                  className="pointer-events-none absolute inset-y-0 w-[2px] bg-amber-500"
-                  style={{ left: 0, transform: `translateX(${currentTimePosition.x}px)` }}
-                />
-              ) : null}
-
-              <div className="space-y-3 pt-6">
-                {VEHICLES.map((v) => (
+              <div className="relative" style={{ width: CONTENT_WIDTH }}>
+                <GridOverlay hourPx={60 * pxPerMin} />
+                {currentTimePosition.visible ? (
                   <div
-                    key={v.id}
-                    data-vehicle-id={v.id}
-                    className="relative h-16 border rounded-xl bg-white overflow-hidden"
-                    onDragOver={handleLaneDragOver}
-                    onDragLeave={handleLaneDragLeave}
-                    onDrop={(e) => handleLaneDrop(v.id, e)}
-                  >
-                    {(appDutiesByVehicle.get(v.id) || []).map((a: any) => (
-                    <AppDutyBlock
-                      key={a.id}
-                      duty={a}
-                      pxPerMin={pxPerMin}
-                      viewDate={viewDate}
-                      isOvernight={a.is_overnight}
-                      overnightFromPreviousDay={a.overnight_from_previous_day}
-                      overnightToNextDay={a.overnight_to_next_day}
-                      onClick={() => openDrawer({ type: "duty", data: a, vehicle: v })}
-                      isSelected={selected?.type === "duty" && selected?.id === a.id}
-                      onMoveDutyToVehicle={(dutyId, fromVehicleId, destVehicleId) => moveDutyByPointer(dutyId, fromVehicleId, destVehicleId)}
-                      onDriverDrop={(dutyId, driverId) => assignDriverToAppDuty(dutyId, driverId)}
-                      onResize={(dutyId, nextStart, nextEnd) => handleResizeDuty(dutyId, nextStart, nextEnd)}
-                    />
-                    ))}
-                    {(bookingsByVehicle.get(v.id) || []).map((b: BoardBooking) => (
-                      <BookingBlock
-                        key={b.id}
-                        booking={b}
-                        pxPerMin={pxPerMin}
-                        viewDate={viewDate}
-                        isOvernight={b.is_overnight}
-                        overnightFromPreviousDay={b.overnight_from_previous_day}
-                        overnightToNextDay={b.overnight_to_next_day}
-                        onClick={() => openDrawer({ type: "booking", data: b, vehicle: v })}
-                        isSelected={selected?.type === "booking" && selected?.id === b.id}
-                        resizable={isAppJob(b)}
-                        onDriverDrop={(bookingId: number, driverId: number) => {
-                          const cur = bookings.find((x) => x.id === bookingId);
-                          if (!cur) return;
-                          if (cur.driverId === driverId) return;
-                          if (cur.driverId != null && cur.driverId !== driverId) {
-                            const currentDriverName = driverMap.get(cur.driverId)?.name ?? "現在ドライバー";
-                            const incomingDriverName = driverMap.get(driverId)?.name ?? "新ドライバー";
-                            const ok =
-                              typeof window === "undefined"
-                                ? true
-                                : window.confirm(`現在: ${currentDriverName} → 新: ${incomingDriverName} に変更しますか？`);
-                            if (!ok) return;
-                          }
-                          const cand: BoardBooking = { ...cur, driverId };
-                          if (hasDriverTimeConflict(bookings, cand)) {
-                            alert("同一ドライバーの時間重複のため割当できません");
-                            return;
-                          }
-                          setBookings((prev) => prev.map((x) => (x.id === bookingId ? { ...x, driverId } : x)));
-                        }}
-                        onMoveToVehicle={(bookingId, fromVehicleId, destVehicleId, originalDriverId) =>
-                          moveBookingByPointer(bookingId, fromVehicleId, destVehicleId, originalDriverId)
-                        }
-                        draggable
-                        onDragStart={(e) => {
-                          e.dataTransfer.effectAllowed = "move";
-                          e.dataTransfer.setData("text/x-booking-id", String(b.id));
-                          e.dataTransfer.setData("text/x-booking-move", String(b.id));
-                          e.dataTransfer.setData("text/x-from-vehicle-id", String(b.vehicleId));
-                          e.dataTransfer.setData("text/x-original-driver-id", b.driverId != null ? String(b.driverId) : "");
-                          e.dataTransfer.setData("text/plain", String(b.id));
-                        }}
-                        flashUnassign={flashUnassignId === b.id}
-                        onResize={(bookingId, nextStart, nextEnd) => handleResizeBooking(bookingId, nextStart, nextEnd)}
-                      />
-                    ))}
+                    className="pointer-events-none absolute inset-y-0 w-[2px] bg-amber-500"
+                    style={{ left: 0, transform: `translateX(${currentTimePosition.x}px)` }}
+                  />
+                ) : null}
 
-                    <div className="absolute left-2 top-1 text-[11px] text-slate-500 bg-white/80 rounded px-1">{v.name}</div>
-                  </div>
-                ))}
+                <div className="space-y-3 pt-6">
+                  {VEHICLES.map((v) => (
+                    <div
+                      key={v.id}
+                      data-vehicle-id={v.id}
+                      className="relative h-16 border rounded-xl bg-white overflow-hidden"
+                      onDragOver={handleLaneDragOver}
+                      onDragLeave={handleLaneDragLeave}
+                      onDrop={(e) => handleLaneDrop(v.id, e)}
+                    >
+                      {(appDutiesByVehicle.get(v.id) || []).map((a: any) => (
+                        <AppDutyBlock
+                          key={a.id}
+                          duty={a}
+                          pxPerMin={pxPerMin}
+                          viewDate={viewDate}
+                          isOvernight={a.is_overnight}
+                          overnightFromPreviousDay={a.overnight_from_previous_day}
+                          overnightToNextDay={a.overnight_to_next_day}
+                          onClick={() => openDrawer({ type: "duty", data: a, vehicle: v })}
+                          isSelected={selected?.type === "duty" && selected?.id === a.id}
+                          onMoveDutyToVehicle={(dutyId, fromVehicleId, destVehicleId) =>
+                            moveDutyByPointer(dutyId, fromVehicleId, destVehicleId)
+                          }
+                          onDriverDrop={(dutyId, driverId) => assignDriverToAppDuty(dutyId, driverId)}
+                          onResize={(dutyId, nextStart, nextEnd) => handleResizeDuty(dutyId, nextStart, nextEnd)}
+                        />
+                      ))}
+                      {(bookingsByVehicle.get(v.id) || []).map((b: BoardBooking) => (
+                        <BookingBlock
+                          key={b.id}
+                          booking={b}
+                          pxPerMin={pxPerMin}
+                          viewDate={viewDate}
+                          isOvernight={b.is_overnight}
+                          overnightFromPreviousDay={b.overnight_from_previous_day}
+                          overnightToNextDay={b.overnight_to_next_day}
+                          onClick={() => openDrawer({ type: "booking", data: b, vehicle: v })}
+                          isSelected={selected?.type === "booking" && selected?.id === b.id}
+                          resizable={isAppJob(b)}
+                          onDriverDrop={(bookingId: number, driverId: number) => {
+                            const cur = bookings.find((x) => x.id === bookingId);
+                            if (!cur) return;
+                            if (cur.driverId === driverId) return;
+                            if (cur.driverId != null && cur.driverId !== driverId) {
+                              const currentDriverName = driverMap.get(cur.driverId)?.name ?? "現在ドライバー";
+                              const incomingDriverName = driverMap.get(driverId)?.name ?? "新ドライバー";
+                              const ok =
+                                typeof window === "undefined"
+                                  ? true
+                                  : window.confirm(`現在: ${currentDriverName} → 新: ${incomingDriverName} に変更しますか？`);
+                              if (!ok) return;
+                            }
+                            const cand: BoardBooking = { ...cur, driverId };
+                            if (hasDriverTimeConflict(bookings, cand)) {
+                              alert("同一ドライバーの時間重複のため割当できません");
+                              return;
+                            }
+                            setBookings((prev) => prev.map((x) => (x.id === bookingId ? { ...x, driverId } : x)));
+                          }}
+                          onMoveToVehicle={(bookingId, fromVehicleId, destVehicleId, originalDriverId) =>
+                            moveBookingByPointer(bookingId, fromVehicleId, destVehicleId, originalDriverId)
+                          }
+                          draggable
+                          onDragStart={(e) => {
+                            e.dataTransfer.effectAllowed = "move";
+                            e.dataTransfer.setData("text/x-booking-id", String(b.id));
+                            e.dataTransfer.setData("text/x-booking-move", String(b.id));
+                            e.dataTransfer.setData("text/x-from-vehicle-id", String(b.vehicleId));
+                            e.dataTransfer.setData("text/x-original-driver-id", b.driverId != null ? String(b.driverId) : "");
+                            e.dataTransfer.setData("text/plain", String(b.id));
+                          }}
+                          flashUnassign={flashUnassignId === b.id}
+                          onResize={(bookingId, nextStart, nextEnd) => handleResizeBooking(bookingId, nextStart, nextEnd)}
+                        />
+                      ))}
+
+                      <div className="absolute left-2 top-1 text-[11px] text-slate-500 bg-white/80 rounded px-1">{v.name}</div>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- wrap the motor pool timeline in a relative container so the overnight navigation buttons can be overlaid at the edges
- keep the scrollable centerRef content unchanged while ensuring the overlay buttons remain clickable during horizontal scrolling

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_b_68e34ad4bc388322ad73c04412be8b27