### PR TITLE
Fix spacing between motor and job pools

### DIFF
--- a/client/src/components/VehicleDispatchBoardMock.tsx
+++ b/client/src/components/VehicleDispatchBoardMock.tsx
@@ -1199,8 +1199,8 @@ export default function VehicleDispatchBoardMock() {
           </div>
         </div>
 
-        <div className="flex gap-3 h-[560px]">
-          <div className="bg-white rounded-2xl shadow p-3 overflow-auto relative" style={{ width: driverWidth }}>
+        <div className="flex gap-3">
+          <div className="bg-white rounded-2xl shadow p-3 overflow-auto relative max-h-[560px]" style={{ width: driverWidth }}>
             <div className="flex items-center justify-between mb-2">
               <h2 className="font-medium">ドライバープール</h2>
               <span className="text-xs text-slate-500">ドラッグで幅調整</span>


### PR DESCRIPTION
## Summary
- remove the fixed 560px height constraint on the motor pool flex container to eliminate the large gap before the job pool
- cap only the driver pool column with a max height so it still scrolls when the list is long

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e3867354988322929e1f081b09d472