### PR TITLE
Adjust pool columns to avoid pushing job pool

### DIFF
--- a/client/src/components/DispatchBoardLayout.tsx
+++ b/client/src/components/DispatchBoardLayout.tsx
@@ -10,10 +10,10 @@ type DispatchBoardLayoutProps = {
 const DispatchBoardLayout = ({ driverPool, motorPool, summary, jobPool }: DispatchBoardLayoutProps) => {
   return (
     <div className="space-y-5">
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[260px_minmax(0,1fr)_280px]">
-        <div className="min-h-[420px]">{driverPool}</div>
-        <div className="min-h-[420px]">{motorPool}</div>
-        <div className="min-h-[420px]">{summary}</div>
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[260px_minmax(0,1fr)_280px] xl:auto-rows-[minmax(0,1fr)] xl:items-start">
+        <div className="min-h-[420px] xl:h-full xl:min-h-0">{driverPool}</div>
+        <div className="min-h-[420px] xl:h-full xl:min-h-0">{motorPool}</div>
+        <div className="min-h-[420px] xl:h-full xl:min-h-0">{summary}</div>
       </div>
       <div>{jobPool}</div>
     </div>

--- a/client/src/components/DriverPool.tsx
+++ b/client/src/components/DriverPool.tsx
@@ -7,7 +7,7 @@ type DriverPoolProps = {
 
 const DriverPool = ({ drivers }: DriverPoolProps) => {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col">
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col overflow-hidden xl:max-h-[calc(100vh-240px)]">
       <div className="px-4 py-3 border-b border-slate-200">
         <h2 className="text-lg font-semibold text-slate-700">Driver Pool</h2>
         <p className="text-xs text-slate-500">Drag drivers onto reservations</p>
@@ -17,7 +17,7 @@ const DriverPool = ({ drivers }: DriverPoolProps) => {
           <div
             ref={provided.innerRef}
             {...provided.droppableProps}
-            className={`flex-1 overflow-y-auto px-4 py-4 space-y-3 transition-colors ${
+            className={`flex-1 overflow-y-auto px-4 py-4 space-y-3 transition-colors min-h-0 ${
               snapshot.isDraggingOver ? "bg-sky-50" : "bg-white"
             }`}
           >

--- a/client/src/components/MotorPoolTimeline.tsx
+++ b/client/src/components/MotorPoolTimeline.tsx
@@ -10,14 +10,14 @@ type MotorPoolTimelineProps = {
 
 const MotorPoolTimeline = ({ lanes, reservations, jobs, drivers }: MotorPoolTimelineProps) => {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col">
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col overflow-hidden xl:max-h-[calc(100vh-240px)]">
       <div className="px-4 py-3 border-b border-slate-200 flex items-center justify-between">
         <div>
           <h2 className="text-lg font-semibold text-slate-700">Motor Pool Timeline</h2>
           <p className="text-xs text-slate-500">Reorder reservations or drop jobs & drivers into cards</p>
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
         {lanes.map((lane) => (
           <Droppable droppableId={`lane-${lane.id}`} type="RESERVATION" key={lane.id}>
             {(provided) => (


### PR DESCRIPTION
## Summary
- align the dispatch board grid so the driver, motor, and summary columns share height on wide layouts
- cap the driver and motor pool cards with viewport-based max heights and preserve internal scrolling to avoid pushing the job pool down

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4dbb4027c832299e8d9028c68751e