### PR TITLE
Restore job timeline total amount display

### DIFF
--- a/client/src/components/VehicleDispatchBoardMock.tsx
+++ b/client/src/components/VehicleDispatchBoardMock.tsx
@@ -729,6 +729,18 @@ export default function VehicleDispatchBoardMock() {
 
     return rows.sort((a, b) => a.sortKey - b.sortKey);
   }, [appDuties, bookings, jobPool, viewDateObj]);
+  const jobAmountSummary = useMemo(() => {
+    return dailyJobRows.reduce<{ total: number; hasAmount: boolean }>(
+      (acc, row) => {
+        if (row.amount != null) {
+          acc.total += row.amount;
+          acc.hasAmount = true;
+        }
+        return acc;
+      },
+      { total: 0, hasAmount: false }
+    );
+  }, [dailyJobRows]);
   const totalMonthlyJobs = useMemo(
     () => DRIVERS.reduce((acc, driver) => acc + driver.monthlyJobs, 0),
     []
@@ -1698,6 +1710,11 @@ export default function VehicleDispatchBoardMock() {
                 </div>
                 <div className="flex flex-wrap items-center gap-4 text-xs text-slate-600">
                   <div>本日のジョブ {dailyJobRows.length} 件</div>
+                  {showJobAmounts && jobAmountSummary.hasAmount && (
+                    <div className="font-semibold text-slate-700">
+                      合計金額 {formatCurrency(jobAmountSummary.total)}
+                    </div>
+                  )}
                   <label className="inline-flex items-center gap-2">
                     <input
                       type="checkbox"


### PR DESCRIPTION
## Summary
- recompute the total of job amounts from the daily job rows
- surface the aggregated amount in the job timeline header when totals are shown

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e56691c7e08322ae6234668c689e04