### PR TITLE
Add vehicle ledger page and connect motor pool data

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,79 @@
-// client/src/App.tsx
+import { useMemo, useState } from "react";
 import VehicleDispatchBoardMock from "./components/VehicleDispatchBoardMock";
+import VehicleLedgerPage from "./components/VehicleLedgerPage";
+import { vehicleLedger, vehicleMaintenanceRecords } from "./data/vehicles";
+
+type ActivePage = "dispatch" | "vehicles";
+
+type NavItem = {
+  key: ActivePage;
+  label: string;
+  description: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  {
+    key: "dispatch",
+    label: "配車ボード",
+    description: "ジョブ・ドライバー・車両の配車状況を確認します。"
+  },
+  {
+    key: "vehicles",
+    label: "車両台帳",
+    description: "登録車両の車検・点検・整備情報を一覧管理します。"
+  }
+];
 
 export default function App() {
+  const [activePage, setActivePage] = useState<ActivePage>("dispatch");
+
+  const activeDescription = useMemo(() => {
+    return NAV_ITEMS.find((item) => item.key === activePage)?.description ?? "";
+  }, [activePage]);
+
   return (
-    <div className="h-screen">
-      <VehicleDispatchBoardMock />
+    <div className="flex min-h-screen flex-col bg-slate-100 text-slate-900">
+      <header className="border-b border-slate-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Hire Dispatch Desk</p>
+            <h1 className="text-xl font-bold text-slate-900">
+              {NAV_ITEMS.find((item) => item.key === activePage)?.label ?? ""}
+            </h1>
+            <p className="text-xs text-slate-500">{activeDescription}</p>
+          </div>
+          <nav className="flex flex-wrap gap-2">
+            {NAV_ITEMS.map((item) => {
+              const isActive = item.key === activePage;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => setActivePage(item.key)}
+                  className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    isActive
+                      ? "bg-slate-900 text-white shadow"
+                      : "border border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:text-slate-800"
+                  }`}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+      </header>
+      <main className="flex-1">
+        {activePage === "dispatch" ? (
+          <VehicleDispatchBoardMock onOpenVehicleLedger={() => setActivePage("vehicles")} />
+        ) : (
+          <VehicleLedgerPage
+            vehicles={vehicleLedger}
+            maintenanceRecords={vehicleMaintenanceRecords}
+            onBackToDispatch={() => setActivePage("dispatch")}
+          />
+        )}
+      </main>
     </div>
   );
 }

--- a/client/src/components/VehicleDispatchBoardMock.tsx
+++ b/client/src/components/VehicleDispatchBoardMock.tsx
@@ -4,6 +4,7 @@ import { useFlashOnChange } from "../lib/useFlashOnChange";
 import type { DragEvent as ReactDragEvent, FormEvent, ReactNode } from "react";
 
 import "./VehicleDispatchBoardMock.css";
+import { vehiclesForDispatch } from "../data/vehicles";
 
 const hours = Array.from({ length: 25 }, (_, i) => i);
 const DRIVER_POOL_WIDTH_INIT = 240;
@@ -19,12 +20,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 type Interval = { start: number; end: number };
 
-const VEHICLES = [
-  { id: 11, name: "セダンA", plate: "品川300 あ 12-34", class: "sedan" },
-  { id: 12, name: "ワゴンB", plate: "品川300 い 56-78", class: "van" },
-  { id: 13, name: "ハイグレードC", plate: "品川300 う 90-12", class: "luxury" },
-  { id: 14, name: "ワゴンD", plate: "品川300 え 34-56", class: "van" }
-];
+const VEHICLES = vehiclesForDispatch;
 const VEHICLE_CLASS_LABELS: Record<string, string> = {
   sedan: "セダン",
   van: "ワゴン",
@@ -507,7 +503,13 @@ function computeFreeSlots(mergedIntervals: Interval[], dayStart: number, dayEnd:
   return slots;
 }
 
-export default function VehicleDispatchBoardMock() {
+type VehicleDispatchBoardMockProps = {
+  onOpenVehicleLedger?: () => void;
+};
+
+export default function VehicleDispatchBoardMock({
+  onOpenVehicleLedger
+}: VehicleDispatchBoardMockProps) {
   const [fullView, setFullView] = useState(false);
   const [pxPerMin, setPxPerMin] = useState(DEFAULT_PX_PER_MIN);
   const [driverWidth, setDriverWidth] = useState(() => {
@@ -1854,7 +1856,11 @@ export default function VehicleDispatchBoardMock() {
                 </div>
                 <div className="flex flex-wrap gap-3">
                   <a
-                    href="/vehicle-ledger"
+                    href="#"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      onOpenVehicleLedger?.();
+                    }}
                     className="inline-flex items-center justify-center gap-2 rounded-full bg-slate-800 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700"
                   >
                     車両情報ページを開く

--- a/client/src/components/VehicleLedgerPage.tsx
+++ b/client/src/components/VehicleLedgerPage.tsx
@@ -1,0 +1,286 @@
+import { useMemo } from "react";
+import type {
+  VehicleClass,
+  VehicleLedgerVehicle,
+  VehicleMaintenanceRecord
+} from "../data/vehicles";
+
+const supportLabels: { key: keyof VehicleLedgerVehicle["appsSupported"]; label: string }[] = [
+  { key: "uber", label: "Uber" },
+  { key: "go", label: "GO" },
+  { key: "diDi", label: "DiDi" },
+  { key: "nearMe", label: "nearMe" }
+];
+
+const vehicleClassLabels: Record<VehicleClass, string> = {
+  sedan: "セダン",
+  van: "ワゴン",
+  luxury: "ハイグレード",
+  suv: "SUV",
+  minibus: "マイクロバス"
+};
+
+type VehicleLedgerPageProps = {
+  vehicles: VehicleLedgerVehicle[];
+  maintenanceRecords: VehicleMaintenanceRecord[];
+  onBackToDispatch?: () => void;
+};
+
+const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit"
+});
+
+function formatDate(value?: string) {
+  if (!value) {
+    return "未設定";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return dateFormatter.format(date);
+}
+
+function expiryStatus(dateString: string) {
+  const now = new Date();
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return {
+      label: "未設定",
+      className: "bg-slate-100 text-slate-500 border border-slate-200"
+    };
+  }
+  const diffDays = Math.round((date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays < 0) {
+    return {
+      label: `${formatDate(dateString)}（期限切れ）`,
+      className: "bg-rose-100 text-rose-700 border border-rose-200"
+    };
+  }
+  if (diffDays <= 30) {
+    return {
+      label: `${formatDate(dateString)}（残り${diffDays}日）`,
+      className: "bg-amber-100 text-amber-700 border border-amber-200"
+    };
+  }
+  return {
+    label: formatDate(dateString),
+    className: "bg-emerald-100 text-emerald-700 border border-emerald-200"
+  };
+}
+
+function formatOdometer(value: number | undefined) {
+  if (value == null) {
+    return "-";
+  }
+  return `${value.toLocaleString()} km`;
+}
+
+export default function VehicleLedgerPage({
+  vehicles,
+  maintenanceRecords,
+  onBackToDispatch
+}: VehicleLedgerPageProps) {
+  const maintenanceByVehicle = useMemo(() => {
+    const map = new Map<number, VehicleMaintenanceRecord[]>();
+    for (const record of maintenanceRecords) {
+      const list = map.get(record.vehicleId);
+      if (list) {
+        list.push(record);
+      } else {
+        map.set(record.vehicleId, [record]);
+      }
+    }
+    for (const [, list] of map) {
+      list.sort((a, b) => new Date(b.performedAt).getTime() - new Date(a.performedAt).getTime());
+    }
+    return map;
+  }, [maintenanceRecords]);
+
+  return (
+    <div className="min-h-full bg-slate-100 pb-12">
+      <div className="mx-auto w-full max-w-6xl px-6 pt-10">
+        <div className="flex flex-col gap-4 pb-8">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Vehicle Ledger</p>
+              <h1 className="text-2xl font-bold text-slate-900">車両台帳</h1>
+              <p className="mt-1 text-sm text-slate-600">
+                車両情報ページで登録した全車両の基本情報と整備履歴を一覧で確認できます。
+              </p>
+            </div>
+            {onBackToDispatch && (
+              <button
+                type="button"
+                onClick={onBackToDispatch}
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:border-slate-400 hover:text-slate-800"
+              >
+                配車ボードに戻る
+              </button>
+            )}
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <p className="text-xs uppercase text-slate-500">登録台数</p>
+              <p className="mt-1 text-2xl font-semibold text-slate-900">{vehicles.length} 台</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <p className="text-xs uppercase text-slate-500">本日車検期限の車両</p>
+              <p className="mt-1 text-2xl font-semibold text-amber-600">
+                {
+                  vehicles.filter((vehicle) => {
+                    const expiry = new Date(vehicle.shakenExpiry);
+                    const today = new Date();
+                    return (
+                      !Number.isNaN(expiry.getTime()) &&
+                      expiry.getFullYear() === today.getFullYear() &&
+                      expiry.getMonth() === today.getMonth() &&
+                      expiry.getDate() === today.getDate()
+                    );
+                  }).length
+                }
+                台
+              </p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <p className="text-xs uppercase text-slate-500">整備履歴件数</p>
+              <p className="mt-1 text-2xl font-semibold text-slate-900">{maintenanceRecords.length} 件</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          {vehicles.map((vehicle) => {
+            const summary = expiryStatus(vehicle.shakenExpiry);
+            const inspection = expiryStatus(vehicle.inspection3mExpiry);
+            const records = maintenanceByVehicle.get(vehicle.id) ?? [];
+
+            return (
+              <section
+                key={vehicle.id}
+                className="rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:shadow-md"
+              >
+                <div className="border-b border-slate-100 px-6 py-5">
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-slate-500">{vehicle.vehiclesId}</p>
+                      <div className="mt-1 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                        <h2 className="text-xl font-semibold text-slate-900">{vehicle.name}</h2>
+                        <span className="text-sm text-slate-600">{vehicle.plateNo}</span>
+                        <span className="text-xs text-slate-500">VIN: {vehicle.vin}</span>
+                      </div>
+                      <p className="mt-2 text-sm text-slate-600">
+                        所属営業所: <span className="font-medium text-slate-800">{vehicle.officeId}</span>
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {supportLabels.map(({ key, label }) => {
+                        const active = vehicle.appsSupported[key];
+                        return (
+                          <span
+                            key={key}
+                            className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${
+                              active
+                                ? "border-sky-300 bg-sky-50 text-sky-700"
+                                : "border-slate-200 bg-slate-100 text-slate-400"
+                            }`}
+                          >
+                            {label}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)]">
+                  <div className="space-y-4 text-sm text-slate-700">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">車両区分</p>
+                        <p className="mt-1 text-base font-medium text-slate-800">
+                          {vehicleClassLabels[vehicle.class] ?? vehicle.class}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">乗車定員</p>
+                        <p className="mt-1 text-base font-medium text-slate-800">{vehicle.seats} 名</p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">保有区分</p>
+                        <p className="mt-1 text-base font-medium text-slate-800">{vehicle.ownerType}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">点検メモ</p>
+                        <p className="mt-1 text-base text-slate-700">
+                          {vehicle.maintenanceNotes ?? "メモなし"}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">車検満了日</p>
+                        <span className={`mt-1 inline-flex w-fit items-center rounded-full px-3 py-1 text-xs font-semibold ${summary.className}`}>
+                          {summary.label}
+                        </span>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-slate-500">3ヶ月点検期限</p>
+                        <span className={`mt-1 inline-flex w-fit items-center rounded-full px-3 py-1 text-xs font-semibold ${inspection.className}`}>
+                          {inspection.label}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50/60 p-4">
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-sm font-semibold text-slate-800">整備履歴</h3>
+                      <span className="text-xs text-slate-500">{records.length} 件</span>
+                    </div>
+                    <div className="mt-3 space-y-3">
+                      {records.length === 0 ? (
+                        <p className="text-xs text-slate-500">整備記録がまだ登録されていません。</p>
+                      ) : (
+                        <table className="w-full table-fixed text-xs text-slate-600">
+                          <thead className="text-[11px] uppercase tracking-wide text-slate-500">
+                            <tr className="text-left">
+                              <th className="w-[70px] pb-2">区分</th>
+                              <th className="w-[96px] pb-2">実施日</th>
+                              <th className="w-[90px] pb-2">走行距離</th>
+                              <th className="w-[120px] pb-2">業者</th>
+                              <th className="pb-2">内容</th>
+                              <th className="w-[96px] pb-2">次回予定</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-slate-200">
+                            {records.map((record) => (
+                              <tr key={record.id} className="align-top">
+                                <td className="py-2 font-medium text-slate-700">{record.type}</td>
+                                <td className="py-2">{formatDate(record.performedAt)}</td>
+                                <td className="py-2">{formatOdometer(record.odometer)}</td>
+                                <td className="py-2">
+                                  {record.vendorName ?? record.vendorId ?? "-"}
+                                </td>
+                                <td className="py-2 text-slate-700">
+                                  {record.notes ?? "-"}
+                                </td>
+                                <td className="py-2">{formatDate(record.nextDueAt)}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/data/vehicles.ts
+++ b/client/src/data/vehicles.ts
@@ -1,0 +1,218 @@
+export type VehicleClass = "sedan" | "van" | "luxury" | "suv" | "minibus";
+export type OwnerType = "自社" | "協力" | "レンタル";
+
+export type VehicleLedgerVehicle = {
+  id: number;
+  vehiclesId: string;
+  officeId: string;
+  name: string;
+  plateNo: string;
+  vin: string;
+  class: VehicleClass;
+  seats: number;
+  ownerType: OwnerType;
+  shakenExpiry: string;
+  inspection3mExpiry: string;
+  maintenanceNotes?: string;
+  appsSupported: {
+    uber: boolean;
+    go: boolean;
+    diDi: boolean;
+    nearMe: boolean;
+  };
+};
+
+export type VehicleMaintenanceRecord = {
+  id: string;
+  vehicleId: number;
+  type: "法定" | "任意" | "3ヶ月";
+  performedAt: string;
+  odometer: number;
+  vendorId?: string;
+  vendorName?: string;
+  notes?: string;
+  nextDueAt?: string;
+};
+
+export const vehicleLedger: VehicleLedgerVehicle[] = [
+  {
+    id: 11,
+    vehiclesId: "VH-00011",
+    officeId: "TOKYO-01",
+    name: "セダンA",
+    plateNo: "品川300 あ 12-34",
+    vin: "JF1BT67C34G012345",
+    class: "sedan",
+    seats: 4,
+    ownerType: "自社",
+    shakenExpiry: "2025-02-28",
+    inspection3mExpiry: "2024-06-15",
+    maintenanceNotes: "スタッドレスタイヤ要交換（11月）",
+    appsSupported: {
+      uber: true,
+      go: true,
+      diDi: false,
+      nearMe: true
+    }
+  },
+  {
+    id: 12,
+    vehiclesId: "VH-00012",
+    officeId: "TOKYO-01",
+    name: "ワゴンB",
+    plateNo: "品川300 い 56-78",
+    vin: "JTMHU01J704020001",
+    class: "van",
+    seats: 7,
+    ownerType: "自社",
+    shakenExpiry: "2026-08-10",
+    inspection3mExpiry: "2024-05-30",
+    maintenanceNotes: "左側スライドドアローラーの摩耗確認中",
+    appsSupported: {
+      uber: true,
+      go: false,
+      diDi: true,
+      nearMe: true
+    }
+  },
+  {
+    id: 13,
+    vehiclesId: "VH-00013",
+    officeId: "TOKYO-02",
+    name: "ハイグレードC",
+    plateNo: "品川300 う 90-12",
+    vin: "JTHBK1GGXF2012345",
+    class: "luxury",
+    seats: 4,
+    ownerType: "協力",
+    shakenExpiry: "2024-11-22",
+    inspection3mExpiry: "2024-07-05",
+    maintenanceNotes: "内装リフレッシュ完了（2024/01）",
+    appsSupported: {
+      uber: false,
+      go: true,
+      diDi: true,
+      nearMe: false
+    }
+  },
+  {
+    id: 14,
+    vehiclesId: "VH-00014",
+    officeId: "YOKOHAMA-01",
+    name: "ワゴンD",
+    plateNo: "品川300 え 34-56",
+    vin: "5TDYK3DC7CS200789",
+    class: "van",
+    seats: 8,
+    ownerType: "レンタル",
+    shakenExpiry: "2025-05-18",
+    inspection3mExpiry: "2024-08-20",
+    maintenanceNotes: "ハイシーズン貸出用。返却後にコーティング予定",
+    appsSupported: {
+      uber: true,
+      go: true,
+      diDi: true,
+      nearMe: true
+    }
+  }
+];
+
+export const vehicleMaintenanceRecords: VehicleMaintenanceRecord[] = [
+  {
+    id: "VM-202403-01",
+    vehicleId: 11,
+    type: "法定",
+    performedAt: "2024-03-12",
+    odometer: 52340,
+    vendorId: "VN-001",
+    vendorName: "東京整備センター",
+    notes: "12ヶ月点検。エンジンオイル／フィルター交換、タイヤローテーション",
+    nextDueAt: "2025-03-12"
+  },
+  {
+    id: "VM-202402-02",
+    vehicleId: 11,
+    type: "3ヶ月",
+    performedAt: "2024-02-05",
+    odometer: 50880,
+    vendorId: "VN-001",
+    vendorName: "東京整備センター",
+    notes: "ブレーキパッド残量チェック（フロント6mm、リア5mm）",
+    nextDueAt: "2024-05-05"
+  },
+  {
+    id: "VM-202401-05",
+    vehicleId: 12,
+    type: "任意",
+    performedAt: "2024-01-18",
+    odometer: 64210,
+    vendorId: "VN-002",
+    vendorName: "首都圏メンテリース",
+    notes: "スライドドアローラー部グリスアップと点検",
+    nextDueAt: "2024-07-18"
+  },
+  {
+    id: "VM-202310-11",
+    vehicleId: 12,
+    type: "法定",
+    performedAt: "2023-10-02",
+    odometer: 58800,
+    vendorId: "VN-003",
+    vendorName: "品川オートワークス",
+    notes: "車検整備一式。冷却水交換、エアコンフィルター交換",
+    nextDueAt: "2025-10-02"
+  },
+  {
+    id: "VM-202402-08",
+    vehicleId: 13,
+    type: "法定",
+    performedAt: "2024-02-22",
+    odometer: 35800,
+    vendorId: "VN-004",
+    vendorName: "ラグジュアリーガレージ東京",
+    notes: "ショックアブソーバーブッシュ交換。内装クリーニング",
+    nextDueAt: "2025-02-22"
+  },
+  {
+    id: "VM-202401-09",
+    vehicleId: 13,
+    type: "任意",
+    performedAt: "2024-01-11",
+    odometer: 35220,
+    vendorId: "VN-004",
+    vendorName: "ラグジュアリーガレージ東京",
+    notes: "冬用タイヤ交換、ホイールバランス調整",
+    nextDueAt: "2024-12-01"
+  },
+  {
+    id: "VM-202312-14",
+    vehicleId: 14,
+    type: "3ヶ月",
+    performedAt: "2023-12-05",
+    odometer: 41700,
+    vendorId: "VN-005",
+    vendorName: "横浜リース整備",
+    notes: "定期点検。バッテリー比重点検、補充なし",
+    nextDueAt: "2024-03-05"
+  },
+  {
+    id: "VM-202309-03",
+    vehicleId: 14,
+    type: "法定",
+    performedAt: "2023-09-17",
+    odometer: 38950,
+    vendorId: "VN-005",
+    vendorName: "横浜リース整備",
+    notes: "車検整備。ブレーキフルード交換、ワイパーブレード交換",
+    nextDueAt: "2025-09-17"
+  }
+];
+
+export const vehiclesForDispatch = vehicleLedger.map((vehicle) => ({
+  id: vehicle.id,
+  name: vehicle.name,
+  plate: vehicle.plateNo,
+  class: vehicle.class
+}));
+
+export type DispatchVehicle = (typeof vehiclesForDispatch)[number];


### PR DESCRIPTION
## Summary
- add shared vehicle and maintenance datasets for vehicles used across the app
- build a vehicle ledger page that shows registration details and maintenance history
- hook the dispatch board and navigation to the shared vehicles and provide a link into the ledger

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e56b7c8c5c8322843d45475b38e767