### PR TITLE
Adjust maintenance history layout width

### DIFF
--- a/client/src/components/VehicleLedgerPage.tsx
+++ b/client/src/components/VehicleLedgerPage.tsx
@@ -195,7 +195,7 @@ export default function VehicleLedgerPage({
                   </div>
                 </div>
 
-                <div className="grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)]">
+                <div className="space-y-6 px-6 py-6">
                   <div className="space-y-4 text-sm text-slate-700">
                     <div className="grid gap-4 sm:grid-cols-2">
                       <div>
@@ -244,34 +244,36 @@ export default function VehicleLedgerPage({
                       {records.length === 0 ? (
                         <p className="text-xs text-slate-500">整備記録がまだ登録されていません。</p>
                       ) : (
-                        <table className="w-full table-fixed text-xs text-slate-600">
-                          <thead className="text-[11px] uppercase tracking-wide text-slate-500">
-                            <tr className="text-left">
-                              <th className="w-[70px] pb-2">区分</th>
-                              <th className="w-[96px] pb-2">実施日</th>
-                              <th className="w-[90px] pb-2">走行距離</th>
-                              <th className="w-[120px] pb-2">業者</th>
-                              <th className="pb-2">内容</th>
-                              <th className="w-[96px] pb-2">次回予定</th>
-                            </tr>
-                          </thead>
-                          <tbody className="divide-y divide-slate-200">
-                            {records.map((record) => (
-                              <tr key={record.id} className="align-top">
-                                <td className="py-2 font-medium text-slate-700">{record.type}</td>
-                                <td className="py-2">{formatDate(record.performedAt)}</td>
-                                <td className="py-2">{formatOdometer(record.odometer)}</td>
-                                <td className="py-2">
-                                  {record.vendorName ?? record.vendorId ?? "-"}
-                                </td>
-                                <td className="py-2 text-slate-700">
-                                  {record.notes ?? "-"}
-                                </td>
-                                <td className="py-2">{formatDate(record.nextDueAt)}</td>
+                        <div className="overflow-x-auto">
+                          <table className="w-full table-auto text-xs text-slate-600">
+                            <thead className="text-[11px] uppercase tracking-wide text-slate-500">
+                              <tr className="text-left">
+                                <th className="w-[70px] pb-2">区分</th>
+                                <th className="w-[96px] pb-2">実施日</th>
+                                <th className="w-[90px] pb-2">走行距離</th>
+                                <th className="w-[140px] pb-2">業者</th>
+                                <th className="pb-2">内容</th>
+                                <th className="w-[120px] pb-2">次回予定</th>
                               </tr>
-                            ))}
-                          </tbody>
-                        </table>
+                            </thead>
+                            <tbody className="divide-y divide-slate-200">
+                              {records.map((record) => (
+                                <tr key={record.id} className="align-top">
+                                  <td className="py-2 font-medium text-slate-700">{record.type}</td>
+                                  <td className="py-2">{formatDate(record.performedAt)}</td>
+                                  <td className="py-2">{formatOdometer(record.odometer)}</td>
+                                  <td className="py-2">
+                                    {record.vendorName ?? record.vendorId ?? "-"}
+                                  </td>
+                                  <td className="py-2 text-slate-700">
+                                    {record.notes ?? "-"}
+                                  </td>
+                                  <td className="py-2">{formatDate(record.nextDueAt)}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- reposition the maintenance history block to span the full width beneath the vehicle details
- allow the maintenance history table to auto size with horizontal scrolling support to keep text readable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e58bbd9c408322b4194a1d24bd80ef