### PR TITLE
Add partner ledger view and navigation button

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import VehicleDispatchBoardMock from "./components/VehicleDispatchBoardMock";
 import VehicleLedgerPage from "./components/VehicleLedgerPage";
 import DriverLedgerPage from "./components/DriverLedgerPage";
+import PartnerLedgerPage from "./components/PartnerLedgerPage";
 import {
   driverLedger as initialDriverLedger,
   type DriverDocumentInput,
@@ -9,7 +10,7 @@ import {
 } from "./data/drivers";
 import { createDispatchVehicles, vehicleLedger, vehicleMaintenanceRecords } from "./data/vehicles";
 
-type ActivePage = "dispatch" | "vehicles" | "drivers";
+type ActivePage = "dispatch" | "vehicles" | "drivers" | "partners";
 
 type NavItem = {
   key: ActivePage;
@@ -27,6 +28,11 @@ const NAV_ITEMS: NavItem[] = [
     key: "drivers",
     label: "運転者台帳",
     description: "ドライバーの資格・書類・点呼記録を管理します。"
+  },
+  {
+    key: "partners",
+    label: "取引先",
+    description: "取引先・拠点・担当者の情報を管理します。"
   },
   {
     key: "vehicles",
@@ -146,6 +152,8 @@ export default function App() {
         maintenanceRecords={vehicleMaintenanceRecords}
       />
     );
+  } else if (activePage === "partners") {
+    pageContent = <PartnerLedgerPage />;
   } else {
     pageContent = (
       <DriverLedgerPage

--- a/client/src/components/PartnerLedgerPage.tsx
+++ b/client/src/components/PartnerLedgerPage.tsx
@@ -1,0 +1,490 @@
+import { useMemo, useState } from "react";
+import {
+  partnerLedger,
+  type PartnerContact,
+  type PartnerOffice,
+  type PartnerRecord
+} from "../data/partners";
+
+interface PartnerEntry {
+  partner: PartnerRecord;
+  offices: PartnerOffice[];
+  contacts: PartnerContact[];
+}
+
+const formatAddressLines = (
+  postalCode: string,
+  prefecture: string,
+  city: string,
+  addressLine1: string,
+  addressLine2?: string
+) => {
+  const lines = [postalCode ? `〒${postalCode}` : undefined];
+  const address = [prefecture, city, addressLine1].filter(Boolean).join("");
+  if (address) {
+    lines.push(address);
+  }
+  if (addressLine2) {
+    lines.push(addressLine2);
+  }
+  return lines.filter((line): line is string => Boolean(line));
+};
+
+const renderMultiline = (value?: string) => {
+  if (!value) {
+    return <span className="text-slate-400">-</span>;
+  }
+  return value.split("\n").map((line, index) => (
+    <div key={`${line}-${index}`} className="whitespace-pre-line">
+      {line}
+    </div>
+  ));
+};
+
+const searchCandidatesFromPartner = (partner: PartnerRecord) => [
+  partner.displayName,
+  partner.officialName,
+  partner.nameKana,
+  partner.phone,
+  partner.email
+];
+
+const searchCandidatesFromOffice = (office: PartnerOffice) => [
+  office.displayName,
+  office.officialName,
+  office.nameKana,
+  office.phone,
+  office.email
+];
+
+const searchCandidatesFromContact = (contact: PartnerContact) => [
+  contact.name,
+  contact.nameKana,
+  contact.phone,
+  contact.email
+];
+
+export default function PartnerLedgerPage() {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const entries = useMemo<PartnerEntry[]>(
+    () =>
+      partnerLedger.partners.map((partner) => ({
+        partner,
+        offices: partnerLedger.offices.filter((office) => office.partnerId === partner.id),
+        contacts: partnerLedger.contacts.filter((contact) => contact.partnerId === partner.id)
+      })),
+    []
+  );
+
+  const officeLookup = useMemo(() => {
+    const map = new Map<string, PartnerOffice>();
+    partnerLedger.offices.forEach((office) => {
+      map.set(office.id, office);
+    });
+    return map;
+  }, []);
+
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+
+  const filteredEntries = useMemo(() => {
+    if (!normalizedSearch) {
+      return entries;
+    }
+
+    const includesTerm = (value?: string) =>
+      value ? value.toLowerCase().includes(normalizedSearch) : false;
+
+    return entries.filter(({ partner, offices, contacts }) => {
+      const partnerMatches = searchCandidatesFromPartner(partner).some(includesTerm);
+      const officeMatches = offices.some((office) =>
+        searchCandidatesFromOffice(office).some(includesTerm)
+      );
+      const contactMatches = contacts.some((contact) =>
+        searchCandidatesFromContact(contact).some(includesTerm)
+      );
+      return partnerMatches || officeMatches || contactMatches;
+    });
+  }, [entries, normalizedSearch]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-8">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900">取引先</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              ハイヤー/ディスパッチデスク向け取引先の基本情報と拠点・担当者を一元管理します。
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900"
+            >
+              拠点を追加
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-800"
+            >
+              担当者を追加
+            </button>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="relative w-full max-w-xl">
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="表示名・正式名称・“よみ”・拠点名・担当者名・電話・メールで検索"
+              className="w-full rounded-full border border-slate-300 bg-white px-4 py-2 pr-10 text-sm text-slate-900 shadow-sm outline-none transition focus:border-slate-500 focus:ring-2 focus:ring-slate-200"
+            />
+            <svg
+              className="pointer-events-none absolute right-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12.9 14.32a8 8 0 111.414-1.414l3.387 3.386a1 1 0 01-1.414 1.415l-3.387-3.387zM14 8a6 6 0 11-12 0 6 6 0 0112 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+          <p className="text-xs text-slate-500">検索結果：{filteredEntries.length}件</p>
+        </div>
+      </div>
+
+      <div className="space-y-8">
+        {filteredEntries.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-12 text-center text-sm text-slate-500">
+            条件に合致する取引先が見つかりませんでした。検索条件を変更してください。
+          </div>
+        ) : (
+          filteredEntries.map(({ partner, offices, contacts }) => {
+            const partnerAddress = formatAddressLines(
+              partner.postalCode,
+              partner.prefecture,
+              partner.city,
+              partner.addressLine1,
+              partner.addressLine2
+            );
+
+            return (
+              <section
+                key={partner.id}
+                className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
+              >
+                <div className="flex flex-col gap-4 border-b border-slate-100 bg-slate-50/60 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                      <span className="font-semibold">{partner.internalId}</span>
+                      <span className="inline-flex items-center rounded-full bg-slate-200 px-2.5 py-0.5 font-medium text-slate-700">
+                        {partner.category}
+                      </span>
+                    </div>
+                    <h3 className="text-xl font-bold text-slate-900">{partner.hqName}</h3>
+                    <p className="text-sm text-slate-500">表示名：{partner.displayName}</p>
+                  </div>
+                  <div className="flex flex-col items-start gap-2 text-xs text-slate-500 sm:items-end">
+                    <div className="rounded-full bg-slate-900/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-white">
+                      HQ
+                    </div>
+                    <div className="text-right">
+                      <div>代表電話：{partner.phone}</div>
+                      <div>代表メール：{partner.email}</div>
+                      <div>当日連絡先：{partner.emergencyContact ?? "-"}</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-8 px-6 py-6">
+                  <div className="space-y-4">
+                    <h4 className="text-sm font-semibold tracking-wide text-slate-500">取引先（会社/HQ）</h4>
+                    <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2 lg:grid-cols-3">
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          取引先ID（内部用）
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">{partner.internalId}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">区分</dt>
+                        <dd className="mt-1 text-sm text-slate-900">{partner.category}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          表示名（優先表示）
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">{partner.displayName}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          正式名称（任意）
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">
+                          {partner.officialName ?? <span className="text-slate-400">-</span>}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          取引先名の“よみ”（任意）
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">
+                          {partner.nameKana ?? <span className="text-slate-400">-</span>}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          郵便番号・住所
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">
+                          {partnerAddress.map((line) => (
+                            <div key={line}>{line}</div>
+                          ))}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          代表電話
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">{partner.phone}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          代表メール（依頼受付用）
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">{partner.email}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          当日連絡先（24h・任意）
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">
+                          {partner.emergencyContact ?? <span className="text-slate-400">-</span>}
+                        </dd>
+                      </div>
+                      <div className="sm:col-span-2 lg:col-span-3">
+                        <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                          備考
+                        </dt>
+                        <dd className="mt-1 text-sm text-slate-900">{renderMultiline(partner.notes)}</dd>
+                      </div>
+                    </dl>
+                  </div>
+
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <h4 className="text-sm font-semibold tracking-wide text-slate-500">
+                        拠点（営業所）
+                      </h4>
+                      <span className="text-xs text-slate-400">{offices.length} 拠点</span>
+                    </div>
+                    {offices.length === 0 ? (
+                      <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500">
+                        登録された拠点はありません。
+                      </div>
+                    ) : (
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        {offices.map((office) => {
+                          const officeAddress = formatAddressLines(
+                            office.postalCode,
+                            office.prefecture,
+                            office.city,
+                            office.addressLine1,
+                            office.addressLine2
+                          );
+                          return (
+                            <div
+                              key={office.id}
+                              className="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+                            >
+                              <div className="space-y-1">
+                                <div className="text-xs font-semibold text-slate-500">
+                                  {office.internalId}
+                                </div>
+                                <h5 className="text-lg font-semibold text-slate-900">
+                                  {office.displayName}
+                                </h5>
+                                <p className="text-xs text-slate-500">
+                                  正式名称：{office.officialName ?? "-"}
+                                </p>
+                              </div>
+                              <dl className="grid gap-y-3 text-sm">
+                                <div>
+                                  <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                    郵便番号・住所
+                                  </dt>
+                                  <dd className="mt-1 text-slate-900">
+                                    {officeAddress.length > 0 ? (
+                                      officeAddress.map((line) => <div key={line}>{line}</div>)
+                                    ) : (
+                                      <span className="text-slate-400">-</span>
+                                    )}
+                                  </dd>
+                                </div>
+                                <div className="grid grid-cols-2 gap-3">
+                                  <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      代表電話（拠点）
+                                    </dt>
+                                    <dd className="mt-1 text-slate-900">
+                                      {office.phone ?? <span className="text-slate-400">-</span>}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      メール（拠点）
+                                    </dt>
+                                    <dd className="mt-1 text-slate-900">
+                                      {office.email ?? <span className="text-slate-400">-</span>}
+                                    </dd>
+                                  </div>
+                                </div>
+                                <div>
+                                  <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                    当日連絡先（24h・任意）
+                                  </dt>
+                                  <dd className="mt-1 text-slate-900">
+                                    {office.emergencyContact ?? <span className="text-slate-400">-</span>}
+                                  </dd>
+                                </div>
+                                <div>
+                                  <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                    備考
+                                  </dt>
+                                  <dd className="mt-1 text-slate-900">{renderMultiline(office.notes)}</dd>
+                                </div>
+                              </dl>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <h4 className="text-sm font-semibold tracking-wide text-slate-500">
+                        担当者（HQ直下または拠点に紐付け）
+                      </h4>
+                      <span className="text-xs text-slate-400">{contacts.length} 名</span>
+                    </div>
+                    {contacts.length === 0 ? (
+                      <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500">
+                        登録された担当者はありません。
+                      </div>
+                    ) : (
+                      <div className="grid gap-4 lg:grid-cols-2">
+                        {contacts.map((contact) => {
+                          const affiliation =
+                            contact.affiliationType === "office"
+                              ? officeLookup.get(contact.affiliationId)?.displayName ?? "拠点未登録"
+                              : partner.hqName;
+                          return (
+                            <div
+                              key={contact.id}
+                              className="flex h-full flex-col justify-between gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+                            >
+                              <div className="flex flex-col gap-3">
+                                <div className="flex flex-wrap items-start justify-between gap-3">
+                                  <div>
+                                    <div className="text-xs font-semibold text-slate-500">
+                                      {contact.internalId}
+                                    </div>
+                                    <h5 className="text-lg font-semibold text-slate-900">
+                                      {contact.name}
+                                    </h5>
+                                    {contact.nameKana && (
+                                      <p className="text-xs text-slate-500">{contact.nameKana}</p>
+                                    )}
+                                  </div>
+                                  <div className="flex flex-wrap items-center justify-end gap-2">
+                                    <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700">
+                                      {contact.role}
+                                    </span>
+                                    {contact.isPrimary && (
+                                      <span className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-700">
+                                        主担当
+                                      </span>
+                                    )}
+                                    <span
+                                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                                        contact.onCall
+                                          ? "bg-emerald-100 text-emerald-700"
+                                          : "bg-slate-200 text-slate-600"
+                                      }`}
+                                    >
+                                      当日連絡{contact.onCall ? "可" : "不可"}
+                                    </span>
+                                  </div>
+                                </div>
+                                <dl className="grid gap-x-4 gap-y-3 text-sm sm:grid-cols-2">
+                                  <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      所属タイプ
+                                    </dt>
+                                    <dd className="mt-1 text-slate-900">
+                                      {contact.affiliationType === "partner" ? "取引先" : "拠点"}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      所属ID（取引先ID または 拠点ID）
+                                    </dt>
+                                    <dd className="mt-1 text-slate-900">{contact.affiliationId}</dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      所属名
+                                    </dt>
+                                    <dd className="mt-1 text-slate-900">{affiliation}</dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      電話（直通・任意）
+                                    </dt>
+                                    <dd className="mt-1 text-slate-900">
+                                      {contact.phone ?? <span className="text-slate-400">-</span>}
+                                    </dd>
+                                  </div>
+                                  <div>
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      メール
+                                    </dt>
+                                    <dd className="mt-1 break-all text-slate-900">{contact.email}</dd>
+                                  </div>
+                                  <div className="sm:col-span-2">
+                                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                                      備考
+                                    </dt>
+                                    <dd className="mt-1 text-slate-900">{renderMultiline(contact.notes)}</dd>
+                                  </div>
+                                </dl>
+                              </div>
+                              <div className="flex items-center justify-end">
+                                <button
+                                  type="button"
+                                  className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                                >
+                                  紐付け切替
+                                </button>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </section>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/data/partners.ts
+++ b/client/src/data/partners.ts
@@ -1,0 +1,226 @@
+export type PartnerCategory = "旅行会社" | "代理店" | "法人" | "その他";
+
+export interface PartnerRecord {
+  id: string;
+  internalId: string;
+  hqName: string;
+  displayName: string;
+  officialName?: string;
+  nameKana?: string;
+  category: PartnerCategory;
+  postalCode: string;
+  prefecture: string;
+  city: string;
+  addressLine1: string;
+  addressLine2?: string;
+  phone: string;
+  email: string;
+  emergencyContact?: string;
+  notes?: string;
+}
+
+export interface PartnerOffice {
+  id: string;
+  internalId: string;
+  partnerId: string;
+  displayName: string;
+  officialName?: string;
+  nameKana?: string;
+  postalCode: string;
+  prefecture: string;
+  city: string;
+  addressLine1: string;
+  addressLine2?: string;
+  phone?: string;
+  email?: string;
+  emergencyContact?: string;
+  notes?: string;
+}
+
+export type ContactAffiliationType = "partner" | "office";
+
+export type PartnerContactRole = "営業" | "手配" | "運行" | "会計" | "その他";
+
+export interface PartnerContact {
+  id: string;
+  internalId: string;
+  partnerId: string;
+  affiliationType: ContactAffiliationType;
+  affiliationId: string;
+  name: string;
+  nameKana?: string;
+  role: PartnerContactRole;
+  phone?: string;
+  email: string;
+  onCall: boolean;
+  isPrimary: boolean;
+  notes?: string;
+}
+
+export interface PartnerLedgerData {
+  partners: PartnerRecord[];
+  offices: PartnerOffice[];
+  contacts: PartnerContact[];
+}
+
+export const partnerLedger: PartnerLedgerData = {
+  partners: [
+    {
+      id: "partner-001",
+      internalId: "TR-0001",
+      hqName: "サンライズツアーズ 本社",
+      displayName: "サンライズツアーズ",
+      officialName: "株式会社サンライズツアーズ",
+      nameKana: "さんらいずつあーず",
+      category: "旅行会社",
+      postalCode: "100-0001",
+      prefecture: "東京都",
+      city: "千代田区千代田",
+      addressLine1: "1-1-1",
+      addressLine2: "麹町ビル5F",
+      phone: "03-1234-5678",
+      email: "booking@sunrise-tours.jp",
+      emergencyContact: "050-1234-0000",
+      notes: "VIP顧客多数。請求は月末締め翌月末払い。"
+    },
+    {
+      id: "partner-002",
+      internalId: "TR-0018",
+      hqName: "グローブリンク 本社",
+      displayName: "グローブリンク",
+      officialName: "グローブリンク合同会社",
+      nameKana: "ぐろーぶりんく",
+      category: "法人",
+      postalCode: "530-0001",
+      prefecture: "大阪府",
+      city: "大阪市北区梅田",
+      addressLine1: "2-4-9",
+      addressLine2: "梅田スクエアタワー18F",
+      phone: "06-9876-5432",
+      email: "operations@globe-link.co.jp",
+      emergencyContact: "080-2222-4444",
+      notes: "シャトル運行の繁忙期は臨時便あり。支払サイト45日。"
+    }
+  ],
+  offices: [
+    {
+      id: "office-001",
+      internalId: "TR-0001-01",
+      partnerId: "partner-001",
+      displayName: "成田空港営業所",
+      officialName: "サンライズツアーズ 成田空港営業所",
+      nameKana: "なりたくうこうえいぎょうしょ",
+      postalCode: "282-0004",
+      prefecture: "千葉県",
+      city: "成田市古込",
+      addressLine1: "1-1 新東京国際空港内",
+      phone: "0476-22-1111",
+      email: "narita@sunrise-tours.jp",
+      emergencyContact: "070-5555-1234",
+      notes: "早朝便・深夜便の運用あり。"
+    },
+    {
+      id: "office-002",
+      internalId: "TR-0001-02",
+      partnerId: "partner-001",
+      displayName: "関西空港営業所",
+      officialName: "サンライズツアーズ 関西空港営業所",
+      postalCode: "549-0011",
+      prefecture: "大阪府",
+      city: "泉南郡田尻町",
+      addressLine1: "泉州空港中1番地",
+      phone: "072-455-0001",
+      email: "kix@sunrise-tours.jp"
+    },
+    {
+      id: "office-101",
+      internalId: "TR-0018-01",
+      partnerId: "partner-002",
+      displayName: "グローブリンク 東京オフィス",
+      officialName: "グローブリンク合同会社 東京支社",
+      postalCode: "105-0001",
+      prefecture: "東京都",
+      city: "港区虎ノ門",
+      addressLine1: "4-1-8 虎ノ門本社ビル7F",
+      phone: "03-6789-1122",
+      email: "tokyo@globe-link.co.jp",
+      notes: "東京エリアの法人顧客担当。"
+    }
+  ],
+  contacts: [
+    {
+      id: "contact-001",
+      internalId: "TRC-001",
+      partnerId: "partner-001",
+      affiliationType: "partner",
+      affiliationId: "partner-001",
+      name: "佐藤 美咲",
+      nameKana: "さとう みさき",
+      role: "営業",
+      phone: "03-1234-5679",
+      email: "misaki.sato@sunrise-tours.jp",
+      onCall: true,
+      isPrimary: true,
+      notes: "主要案件の窓口。契約更新・料金改定の調整も担当。"
+    },
+    {
+      id: "contact-002",
+      internalId: "TRC-002",
+      partnerId: "partner-001",
+      affiliationType: "office",
+      affiliationId: "office-001",
+      name: "田中 亮",
+      nameKana: "たなか りょう",
+      role: "運行",
+      phone: "0476-22-2222",
+      email: "ryo.tanaka@sunrise-tours.jp",
+      onCall: true,
+      isPrimary: false,
+      notes: "成田空港営業所の当日運行管理者。深夜帯も対応。"
+    },
+    {
+      id: "contact-003",
+      internalId: "TRC-003",
+      partnerId: "partner-001",
+      affiliationType: "office",
+      affiliationId: "office-002",
+      name: "王 明華",
+      nameKana: "おう めいか",
+      role: "手配",
+      email: "meika.oh@sunrise-tours.jp",
+      onCall: false,
+      isPrimary: false,
+      notes: "関西空港営業所の手配担当。中国語案件に強み。"
+    },
+    {
+      id: "contact-101",
+      internalId: "TRC-101",
+      partnerId: "partner-002",
+      affiliationType: "partner",
+      affiliationId: "partner-002",
+      name: "中村 拓真",
+      nameKana: "なかむら たくま",
+      role: "運行",
+      phone: "06-9876-5433",
+      email: "takuma.nakamura@globe-link.co.jp",
+      onCall: true,
+      isPrimary: true,
+      notes: "本社の運行管理責任者。大型案件の主担当。"
+    },
+    {
+      id: "contact-102",
+      internalId: "TRC-102",
+      partnerId: "partner-002",
+      affiliationType: "office",
+      affiliationId: "office-101",
+      name: "小林 彩",
+      nameKana: "こばやし あや",
+      role: "営業",
+      phone: "03-6789-1133",
+      email: "aya.kobayashi@globe-link.co.jp",
+      onCall: false,
+      isPrimary: false,
+      notes: "東京オフィスの法人営業。見積・提案の一次窓口。"
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- add a partner ledger data set and page to manage partner, office, and contact details with search and action controls
- expose the new partner ledger from the main navigation alongside existing dispatch, driver, and vehicle pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e59b24d6ac8322a8b7b2934cc8fbdc