### PR TITLE
Show driver details in modal on driver ledger page

### DIFF
--- a/client/src/components/DriverLedgerPage.tsx
+++ b/client/src/components/DriverLedgerPage.tsx
@@ -112,6 +112,7 @@ export default function DriverLedgerPage({
     uri: "",
     uploadedAt: ""
   });
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
 
   useEffect(() => {
     if (!selectedId) {
@@ -178,6 +179,12 @@ export default function DriverLedgerPage({
   }, [drivers]);
 
   const selectedDriver = selectedId != null ? drivers.find((driver) => driver.id === selectedId) ?? null : null;
+
+  useEffect(() => {
+    if (!selectedDriver) {
+      setIsDetailOpen(false);
+    }
+  }, [selectedDriver]);
 
   const handleNewDriverChange = <K extends keyof NewDriverFormState>(field: K, value: NewDriverFormState[K]) => {
     setNewDriverForm((prev) => ({ ...prev, [field]: value }));
@@ -268,7 +275,7 @@ export default function DriverLedgerPage({
           </div>
         </div>
 
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.4fr)_minmax(0,1fr)]">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
           <section className="rounded-3xl border border-slate-200 bg-white shadow-sm">
             <div className="border-b border-slate-100 px-5 py-4">
               <div className="flex flex-col gap-2">
@@ -297,14 +304,17 @@ export default function DriverLedgerPage({
               {filteredDrivers.length === 0 && (
                 <li className="px-3 py-12 text-center text-sm text-slate-500">該当するドライバーが見つかりません。</li>
               )}
-              {filteredDrivers.map((driver) => {
-                const isSelected = driver.id === selectedId;
-                const statusLabel = driver.status === "archived" ? "アーカイブ" : "稼働中";
-                return (
-                  <li key={driver.id}>
+            {filteredDrivers.map((driver) => {
+              const isSelected = driver.id === selectedId;
+              const statusLabel = driver.status === "archived" ? "アーカイブ" : "稼働中";
+              return (
+                <li key={driver.id}>
                     <button
                       type="button"
-                      onClick={() => setSelectedId(driver.id)}
+                      onClick={() => {
+                        setSelectedId(driver.id);
+                        setIsDetailOpen(true);
+                      }}
                       className={`w-full rounded-2xl border px-4 py-3 text-left transition ${
                         isSelected
                           ? "border-slate-600 bg-slate-900 text-white shadow"
@@ -330,232 +340,21 @@ export default function DriverLedgerPage({
                       </div>
                     </button>
                   </li>
-                );
-              })}
-            </ul>
-          </section>
-
-          <section className="rounded-3xl border border-slate-200 bg-white shadow-sm">
-            <div className="border-b border-slate-100 px-6 py-5">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <h2 className="text-lg font-semibold text-slate-800">台帳詳細</h2>
-                  <p className="text-xs text-slate-500">選択したドライバーの詳細情報と資料フォルダーを表示します。</p>
-                </div>
-                {selectedDriver && (
-                  <div className="flex gap-2">
-                    {selectedDriver.status === "active" ? (
-                      <button
-                        type="button"
-                        onClick={() => onArchiveDriver(selectedDriver.id)}
-                        className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm transition hover:border-rose-400 hover:text-rose-600"
-                      >
-                        アーカイブ
-                      </button>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => onRestoreDriver(selectedDriver.id)}
-                        className="rounded-full border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-600 shadow-sm transition hover:border-emerald-400 hover:bg-emerald-100"
-                      >
-                        復帰
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {selectedDriver ? (
-                <div className="grid gap-6 px-6 py-6 xl:grid-cols-2">
-                  <div className="space-y-5">
-                    <div>
-                      <h3 className="text-sm font-semibold text-slate-700">基本情報</h3>
-                      <dl className="mt-2 grid grid-cols-[auto,1fr] gap-x-3 gap-y-2 text-sm text-slate-700">
-                        <dt className="text-slate-500">コード</dt>
-                        <dd>{selectedDriver.code}</dd>
-                        <dt className="text-slate-500">氏名</dt>
-                        <dd>{selectedDriver.name}</dd>
-                        <dt className="text-slate-500">カナ</dt>
-                        <dd>{selectedDriver.nameKana}</dd>
-                        <dt className="text-slate-500">所属</dt>
-                        <dd>{selectedDriver.officeId || "未設定"}</dd>
-                        <dt className="text-slate-500">電話</dt>
-                        <dd>{selectedDriver.phone || "未登録"}</dd>
-                        <dt className="text-slate-500">メール</dt>
-                        <dd>{selectedDriver.email || "未登録"}</dd>
-                        <dt className="text-slate-500">住所</dt>
-                        <dd>{selectedDriver.address || "未登録"}</dd>
-                        <dt className="text-slate-500">生年月日</dt>
-                        <dd>{formatDate(selectedDriver.birthDate)}</dd>
-                        <dt className="text-slate-500">就業区分</dt>
-                        <dd>{selectedDriver.employmentType}</dd>
-                      </dl>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-semibold text-slate-700">免許・点呼情報</h3>
-                      <dl className="mt-2 grid grid-cols-[auto,1fr] gap-x-3 gap-y-2 text-sm text-slate-700">
-                        <dt className="text-slate-500">免許区分</dt>
-                        <dd>{selectedDriver.licenseClass}</dd>
-                        <dt className="text-slate-500">免許証番号</dt>
-                        <dd>{selectedDriver.licenseNumber || "未登録"}</dd>
-                        <dt className="text-slate-500">免許有効期限</dt>
-                        <dd>{formatDate(selectedDriver.licenseExpiry)}</dd>
-                        <dt className="text-slate-500">最終健診日</dt>
-                        <dd>{formatDate(selectedDriver.lastMedicalCheckAt)}</dd>
-                        <dt className="text-slate-500">健診メモ</dt>
-                        <dd>{selectedDriver.medicalNotes || "-"}</dd>
-                        <dt className="text-slate-500">点呼方法</dt>
-                        <dd>{selectedDriver.alcoholCheckMethod || "未設定"}</dd>
-                        <dt className="text-slate-500">最終点呼</dt>
-                        <dd>{formatDate(selectedDriver.lastAlcoholCheckAt)}</dd>
-                      </dl>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-semibold text-slate-700">稼働状況</h3>
-                      <div className="mt-2 grid grid-cols-3 gap-3">
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-center">
-                          <p className="text-[11px] text-slate-500">今月拡張</p>
-                          <p className="text-base font-semibold text-slate-800">{selectedDriver.extUsageCountMonth} 回</p>
-                        </div>
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-center">
-                          <p className="text-[11px] text-slate-500">今月実績</p>
-                          <p className="text-base font-semibold text-slate-800">{selectedDriver.monthlyJobCount} 件</p>
-                        </div>
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-center">
-                          <p className="text-[11px] text-slate-500">稼働回数</p>
-                          <p className="text-base font-semibold text-slate-800">{selectedDriver.currentDispatchNumber} 件</p>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="space-y-5">
-                    <div>
-                      <h3 className="text-sm font-semibold text-slate-700">資料フォルダー</h3>
-                      <div className="mt-2 space-y-3">
-                        <ul className="space-y-2 text-sm text-slate-700">
-                          {selectedDriver.documents.length === 0 && (
-                            <li className="rounded-xl border border-dashed border-slate-300 px-4 py-6 text-center text-sm text-slate-500">
-                              添付資料は登録されていません。
-                            </li>
-                          )}
-                          {selectedDriver.documents.map((doc) => (
-                            <li
-                              key={doc.id}
-                              className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3"
-                            >
-                              <div className="flex items-center justify-between gap-3">
-                                <div>
-                                  <p className="text-sm font-semibold text-slate-800">{doc.name}</p>
-                                  <p className="text-xs text-slate-500">
-                                    {documentTypeLabels[doc.type]} ／ 登録日：{formatDate(doc.uploadedAt)}
-                                  </p>
-                                  {doc.notes && <p className="mt-1 text-xs text-slate-500">メモ：{doc.notes}</p>}
-                                  {doc.uri && (
-                                    <a
-                                      href={doc.uri}
-                                      target="_blank"
-                                      rel="noreferrer"
-                                      className="mt-1 inline-block text-xs font-medium text-sky-600 hover:text-sky-700"
-                                    >
-                                      資料を開く
-                                    </a>
-                                  )}
-                                </div>
-                              </div>
-                            </li>
-                          ))}
-                        </ul>
-                        <form className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm" onSubmit={handleAddDocument}>
-                          <h4 className="text-sm font-semibold text-slate-700">資料を追加</h4>
-                          <div className="mt-3 grid gap-3">
-                            <div className="grid gap-2 sm:grid-cols-2">
-                              <div>
-                                <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-name">
-                                  資料名
-                                </label>
-                                <input
-                                  id="doc-name"
-                                  type="text"
-                                  value={documentForm.name}
-                                  onChange={(e) => setDocumentForm((prev) => ({ ...prev, name: e.target.value }))}
-                                  className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
-                                  placeholder="例）履歴書 2024"
-                                  required
-                                />
-                              </div>
-                              <div>
-                                <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-type">
-                                  区分
-                                </label>
-                                <select
-                                  id="doc-type"
-                                  value={documentForm.type}
-                                  onChange={(e) =>
-                                    setDocumentForm((prev) => ({
-                                      ...prev,
-                                      type: e.target.value as DriverDocumentType
-                                    }))
-                                  }
-                                  className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
-                                >
-                                  {Object.entries(documentTypeLabels).map(([value, label]) => (
-                                    <option key={value} value={value}>
-                                      {label}
-                                    </option>
-                                  ))}
-                                </select>
-                              </div>
-                            </div>
-                            <div className="grid gap-2 sm:grid-cols-2">
-                              <div>
-                                <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-uploaded">
-                                  登録日
-                                </label>
-                                <input
-                                  id="doc-uploaded"
-                                  type="date"
-                                  value={documentForm.uploadedAt}
-                                  onChange={(e) => setDocumentForm((prev) => ({ ...prev, uploadedAt: e.target.value }))}
-                                  className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
-                                />
-                              </div>
-                              <div>
-                                <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-uri">
-                                  閲覧リンク（任意）
-                                </label>
-                                <input
-                                  id="doc-uri"
-                                  type="url"
-                                  value={documentForm.uri}
-                                  onChange={(e) => setDocumentForm((prev) => ({ ...prev, uri: e.target.value }))}
-                                  placeholder="https://..."
-                                  className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
-                                />
-                              </div>
-                            </div>
-                            <button
-                              type="submit"
-                              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700"
-                            >
-                              資料を保存
-                            </button>
-                          </div>
-                        </form>
-                      </div>
-                    </div>
-                    {selectedDriver.notes && (
-                      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
-                        <h4 className="text-sm font-semibold text-slate-700">備考</h4>
-                        <p className="mt-1 whitespace-pre-line text-sm text-slate-600">{selectedDriver.notes}</p>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ) : (
-                <div className="px-6 py-10 text-center text-sm text-slate-500">表示するドライバーを選択してください。</div>
-              )}
+              );
+            })}
+          </ul>
+          {selectedDriver && (
+            <div className="border-t border-slate-100 px-5 py-4">
+              <button
+                type="button"
+                onClick={() => setIsDetailOpen(true)}
+                className="inline-flex w-full items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:border-slate-400 hover:text-slate-800"
+              >
+                選択中のドライバー詳細を開く
+              </button>
             </div>
-          </section>
+          )}
+        </section>
 
           <section className="rounded-3xl border border-slate-200 bg-white shadow-sm">
             <div className="border-b border-slate-100 px-6 py-5">
@@ -847,6 +646,241 @@ export default function DriverLedgerPage({
           </section>
         </div>
       </div>
+      {selectedDriver && isDetailOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4 py-6"
+          role="dialog"
+          aria-modal="true"
+          aria-label="ドライバー詳細"
+          onClick={() => setIsDetailOpen(false)}
+        >
+          <div
+            className="relative flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-3xl bg-white shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-start justify-between border-b border-slate-100 px-6 py-5">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800">台帳詳細</h2>
+                <p className="text-xs text-slate-500">選択したドライバーの詳細情報と資料フォルダーを表示します。</p>
+              </div>
+              <div className="flex items-center gap-2">
+                {selectedDriver.status === "active" ? (
+                  <button
+                    type="button"
+                    onClick={() => onArchiveDriver(selectedDriver.id)}
+                    className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm transition hover:border-rose-400 hover:text-rose-600"
+                  >
+                    アーカイブ
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onRestoreDriver(selectedDriver.id)}
+                    className="rounded-full border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-600 shadow-sm transition hover:border-emerald-400 hover:bg-emerald-100"
+                  >
+                    復帰
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setIsDetailOpen(false)}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:border-slate-300 hover:text-slate-700"
+                  aria-label="閉じる"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+            <div className="flex-1 overflow-y-auto px-6 py-6">
+              <div className="grid gap-6 xl:grid-cols-2">
+                <div className="space-y-5">
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-700">基本情報</h3>
+                    <dl className="mt-2 grid grid-cols-[auto,1fr] gap-x-3 gap-y-2 text-sm text-slate-700">
+                      <dt className="text-slate-500">コード</dt>
+                      <dd>{selectedDriver.code}</dd>
+                      <dt className="text-slate-500">氏名</dt>
+                      <dd>{selectedDriver.name}</dd>
+                      <dt className="text-slate-500">カナ</dt>
+                      <dd>{selectedDriver.nameKana}</dd>
+                      <dt className="text-slate-500">所属</dt>
+                      <dd>{selectedDriver.officeId || "未設定"}</dd>
+                      <dt className="text-slate-500">電話</dt>
+                      <dd>{selectedDriver.phone || "未登録"}</dd>
+                      <dt className="text-slate-500">メール</dt>
+                      <dd>{selectedDriver.email || "未登録"}</dd>
+                      <dt className="text-slate-500">住所</dt>
+                      <dd>{selectedDriver.address || "未登録"}</dd>
+                      <dt className="text-slate-500">生年月日</dt>
+                      <dd>{formatDate(selectedDriver.birthDate)}</dd>
+                      <dt className="text-slate-500">就業区分</dt>
+                      <dd>{selectedDriver.employmentType}</dd>
+                    </dl>
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-700">免許・点呼情報</h3>
+                    <dl className="mt-2 grid grid-cols-[auto,1fr] gap-x-3 gap-y-2 text-sm text-slate-700">
+                      <dt className="text-slate-500">免許区分</dt>
+                      <dd>{selectedDriver.licenseClass}</dd>
+                      <dt className="text-slate-500">免許証番号</dt>
+                      <dd>{selectedDriver.licenseNumber || "未登録"}</dd>
+                      <dt className="text-slate-500">免許有効期限</dt>
+                      <dd>{formatDate(selectedDriver.licenseExpiry)}</dd>
+                      <dt className="text-slate-500">最終健診日</dt>
+                      <dd>{formatDate(selectedDriver.lastMedicalCheckAt)}</dd>
+                      <dt className="text-slate-500">健診メモ</dt>
+                      <dd>{selectedDriver.medicalNotes || "-"}</dd>
+                      <dt className="text-slate-500">点呼方法</dt>
+                      <dd>{selectedDriver.alcoholCheckMethod || "未設定"}</dd>
+                      <dt className="text-slate-500">最終点呼</dt>
+                      <dd>{formatDate(selectedDriver.lastAlcoholCheckAt)}</dd>
+                    </dl>
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-700">稼働状況</h3>
+                    <div className="mt-2 grid grid-cols-3 gap-3">
+                      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-center">
+                        <p className="text-[11px] text-slate-500">今月拡張</p>
+                        <p className="text-base font-semibold text-slate-800">{selectedDriver.extUsageCountMonth} 回</p>
+                      </div>
+                      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-center">
+                        <p className="text-[11px] text-slate-500">今月実績</p>
+                        <p className="text-base font-semibold text-slate-800">{selectedDriver.monthlyJobCount} 件</p>
+                      </div>
+                      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-center">
+                        <p className="text-[11px] text-slate-500">稼働回数</p>
+                        <p className="text-base font-semibold text-slate-800">{selectedDriver.currentDispatchNumber} 件</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="space-y-5">
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-700">資料フォルダー</h3>
+                    <div className="mt-2 space-y-3">
+                      <ul className="space-y-2 text-sm text-slate-700">
+                        {selectedDriver.documents.length === 0 && (
+                          <li className="rounded-xl border border-dashed border-slate-300 px-4 py-6 text-center text-sm text-slate-500">
+                            添付資料は登録されていません。
+                          </li>
+                        )}
+                        {selectedDriver.documents.map((doc) => (
+                          <li
+                            key={doc.id}
+                            className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3"
+                          >
+                            <div className="flex items-center justify-between gap-3">
+                              <div>
+                                <p className="text-sm font-semibold text-slate-800">{doc.name}</p>
+                                <p className="text-xs text-slate-500">
+                                  {documentTypeLabels[doc.type]} ／ 登録日：{formatDate(doc.uploadedAt)}
+                                </p>
+                                {doc.notes && <p className="mt-1 text-xs text-slate-500">メモ：{doc.notes}</p>}
+                                {doc.uri && (
+                                  <a
+                                    href={doc.uri}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="mt-1 inline-block text-xs font-medium text-sky-600 hover:text-sky-700"
+                                  >
+                                    資料を開く
+                                  </a>
+                                )}
+                              </div>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                      <form className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm" onSubmit={handleAddDocument}>
+                        <h4 className="text-sm font-semibold text-slate-700">資料を追加</h4>
+                        <div className="mt-3 grid gap-3">
+                          <div className="grid gap-2 sm:grid-cols-2">
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-name">
+                                資料名
+                              </label>
+                              <input
+                                id="doc-name"
+                                type="text"
+                                value={documentForm.name}
+                                onChange={(e) => setDocumentForm((prev) => ({ ...prev, name: e.target.value }))}
+                                className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                                placeholder="例）履歴書 2024"
+                                required
+                              />
+                            </div>
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-type">
+                                区分
+                              </label>
+                              <select
+                                id="doc-type"
+                                value={documentForm.type}
+                                onChange={(e) =>
+                                  setDocumentForm((prev) => ({
+                                    ...prev,
+                                    type: e.target.value as DriverDocumentType
+                                  }))
+                                }
+                                className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                              >
+                                {Object.entries(documentTypeLabels).map(([value, label]) => (
+                                  <option key={value} value={value}>
+                                    {label}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                          </div>
+                          <div className="grid gap-2 sm:grid-cols-2">
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-uploaded">
+                                登録日
+                              </label>
+                              <input
+                                id="doc-uploaded"
+                                type="date"
+                                value={documentForm.uploadedAt}
+                                onChange={(e) => setDocumentForm((prev) => ({ ...prev, uploadedAt: e.target.value }))}
+                                className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                              />
+                            </div>
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="doc-uri">
+                                閲覧リンク（任意）
+                              </label>
+                              <input
+                                id="doc-uri"
+                                type="url"
+                                value={documentForm.uri}
+                                onChange={(e) => setDocumentForm((prev) => ({ ...prev, uri: e.target.value }))}
+                                placeholder="https://..."
+                                className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                              />
+                            </div>
+                          </div>
+                          <button
+                            type="submit"
+                            className="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700"
+                          >
+                            資料を保存
+                          </button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+                  {selectedDriver.notes && (
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+                      <h4 className="text-sm font-semibold text-slate-700">備考</h4>
+                      <p className="mt-1 whitespace-pre-line text-sm text-slate-600">{selectedDriver.notes}</p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add modal state to the driver ledger page and trigger it from driver list selections
- remove the inline detail column and render the existing detail content inside a modal overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5e53114dc83228b0a7ebebdb21ff7