### PR TITLE
Reorder nav buttons and rely on modal for driver details

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,14 +30,14 @@ const NAV_ITEMS: NavItem[] = [
     description: "ドライバーの資格・書類・点呼記録を管理します。"
   },
   {
-    key: "partners",
-    label: "取引先",
-    description: "取引先・拠点・担当者の情報を管理します。"
-  },
-  {
     key: "vehicles",
     label: "車両台帳",
     description: "登録車両の車検・点検・整備情報を一覧管理します。"
+  },
+  {
+    key: "partners",
+    label: "取引先",
+    description: "取引先・拠点・担当者の情報を管理します。"
   }
 ];
 

--- a/client/src/components/DriverLedgerPage.tsx
+++ b/client/src/components/DriverLedgerPage.tsx
@@ -343,17 +343,6 @@ export default function DriverLedgerPage({
               );
             })}
           </ul>
-          {selectedDriver && (
-            <div className="border-t border-slate-100 px-5 py-4">
-              <button
-                type="button"
-                onClick={() => setIsDetailOpen(true)}
-                className="inline-flex w-full items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm transition hover:border-slate-400 hover:text-slate-800"
-              >
-                選択中のドライバー詳細を開く
-              </button>
-            </div>
-          )}
         </section>
 
           <section className="rounded-3xl border border-slate-200 bg-white shadow-sm">


### PR DESCRIPTION
## Summary
- reorder the header navigation tabs to the requested 配車ボード → 運転者台帳 → 車両台帳 → 取引先 sequence
- remove the driver ledger footer button so that detailed information is only shown inside the modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e6089dee608322b9865f32c4c8a141