### PR TITLE
Limit driver pool list to ten entries

### DIFF
--- a/client/src/components/DriverPool.tsx
+++ b/client/src/components/DriverPool.tsx
@@ -6,11 +6,14 @@ type DriverPoolProps = {
 };
 
 const DriverPool = ({ drivers }: DriverPoolProps) => {
+  const visibleDrivers = drivers.slice(0, 10);
+  const hiddenDriverCount = Math.max(drivers.length - visibleDrivers.length, 0);
+
   return (
     <div className="bg-white rounded-xl shadow-sm border border-slate-200 h-full flex flex-col overflow-hidden xl:max-h-[calc(100vh-240px)]">
       <div className="px-4 py-3 border-b border-slate-200">
         <h2 className="text-lg font-semibold text-slate-700">Driver Pool</h2>
-        <p className="text-xs text-slate-500">Drag drivers onto reservations</p>
+        <p className="text-xs text-slate-500">Assign drivers by dragging onto reservations.</p>
       </div>
       <Droppable droppableId="driverPool" type="DRIVER">
         {(provided, snapshot) => (
@@ -21,24 +24,29 @@ const DriverPool = ({ drivers }: DriverPoolProps) => {
               snapshot.isDraggingOver ? "bg-sky-50" : "bg-white"
             }`}
           >
-            {drivers.map((driver, index) => (
+            {visibleDrivers.map((driver, index) => (
               <Draggable draggableId={driver.id} index={index} key={driver.id}>
                 {(dragProvided, dragSnapshot) => (
                   <div
                     ref={dragProvided.innerRef}
                     {...dragProvided.draggableProps}
                     {...dragProvided.dragHandleProps}
-                    className={`rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm transition ${
+                    className={`rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm transition text-sm ${
                       dragSnapshot.isDragging ? "ring-2 ring-sky-400" : ""
                     }`}
                   >
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-slate-700">{driver.name}</span>
-                      <span className="text-xs font-semibold uppercase text-emerald-600">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-medium text-slate-700 truncate">{driver.name}</span>
+                      <span
+                        className={`text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full ${
+                          driver.status === "available"
+                            ? "bg-emerald-50 text-emerald-600"
+                            : "bg-amber-50 text-amber-600"
+                        }`}
+                      >
                         {driver.status === "available" ? "Available" : "Assigned"}
                       </span>
                     </div>
-                    <p className="text-xs text-slate-500 mt-1">ID: {driver.id}</p>
                   </div>
                 )}
               </Draggable>
@@ -46,6 +54,11 @@ const DriverPool = ({ drivers }: DriverPoolProps) => {
             {drivers.length === 0 && (
               <p className="text-sm text-slate-500 text-center py-6">
                 All drivers are currently assigned.
+              </p>
+            )}
+            {hiddenDriverCount > 0 && (
+              <p className="text-xs text-slate-500 text-center">
+                +{hiddenDriverCount} more drivers not shown.
               </p>
             )}
             {provided.placeholder}


### PR DESCRIPTION
## Summary
- limit the driver pool panel to rendering only the first ten drivers
- tighten the driver card layout to better fit the increased density
- show a count of any additional drivers not currently visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e6293d27588322a4f82cebfe5d22b0