### PR TITLE
Fix expiry status rounding on vehicle dispatch board

### DIFF
--- a/client/src/components/VehicleDispatchBoardMock.tsx
+++ b/client/src/components/VehicleDispatchBoardMock.tsx
@@ -55,7 +55,7 @@ function resolveExpiryStatus(dateString: string) {
       className: "bg-slate-100 text-slate-500 border border-slate-200"
     };
   }
-  const diffDays = Math.round((date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  const diffDays = Math.floor((date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
   if (diffDays < 0) {
     return {
       label: `${formatExpiryDate(dateString)}（期限切れ）`,


### PR DESCRIPTION
## Summary
- change the expiry status calculation to use Math.floor so that past due inspections are marked expired immediately

## Testing
- npm install (client)
- npm run build (client)


------
https://chatgpt.com/codex/tasks/task_b_690182a12bf08322b8b993a6e771d28f