### PR TITLE
Add Vercel deployment config, README guidance, and Vite base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # HireDispatchDesk
-Cloud-based hire/taxi dispatch and driver management system
+Cloud-based hire/taxi dispatch and driver management system.
+
+## GitHub → Vercel preview (for presentations)
+You can upload this repo to GitHub and let Vercel automatically deploy preview/production URLs.
+
+### What is configured in this repository
+- `vercel.json` is included for this monorepo structure.
+- Vercel installs/builds from the `client` folder and serves `client/dist`.
+- SPA rewrite is enabled so deep links route to `index.html`.
+
+### Setup steps
+1. Push this repository to GitHub.
+2. In Vercel, click **Add New Project** and import this GitHub repository.
+3. Confirm deploy settings (the included `vercel.json` will be used automatically).
+4. Click **Deploy**.
+
+### Result
+- Every push to GitHub will trigger Vercel deployments.
+- You get a shareable URL for today's presentation.

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,6 +4,7 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/",
   plugins: [react()],
   resolve: {
     alias: {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "installCommand": "cd client && npm ci",
+  "buildCommand": "cd client && npm run build",
+  "outputDirectory": "client/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide an easy path to deploy the monorepo to Vercel for previews and presentations.  
- Document the expected repository layout and deployment steps so non-maintainers can create previews quickly.  
- Ensure the client app assets and SPA routing resolve correctly when served from Vercel.

### Description
- Add `vercel.json` that runs `cd client && npm ci` and `cd client && npm run build`, outputs `client/dist`, and rewrites all routes to `/index.html` for SPA routing.  
- Update `README.md` with a "GitHub → Vercel preview" section explaining how to import the repo to Vercel and what is configured.  
- Set `base: "/"` in `client/vite.config.ts` so built assets are served from the root path expected by Vercel.

### Testing
- Ran a local client build with `cd client && npm run build` and the build completed successfully producing `client/dist`.  
- Verified the `vercel.json` rewrite rule and output directory are consistent with the generated `dist` layout via the local build.  
- No unit tests were modified or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f012ee3d348322b06101d25f5ff020)