### PR TITLE
Add 請求書 navigation button with placeholder invoice page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,7 @@ import {
 } from "./data/drivers";
 import { createDispatchVehicles, vehicleLedger, vehicleMaintenanceRecords } from "./data/vehicles";
 
-type ActivePage = "dispatch" | "vehicles" | "drivers" | "partners";
+type ActivePage = "dispatch" | "vehicles" | "drivers" | "partners" | "invoices";
 
 type NavItem = {
   key: ActivePage;
@@ -38,6 +38,11 @@ const NAV_ITEMS: NavItem[] = [
     key: "partners",
     label: "取引先",
     description: "取引先・拠点・担当者の情報を管理します。"
+  },
+  {
+    key: "invoices",
+    label: "請求書",
+    description: "請求書作成画面（Excel風UI）を表示します。"
   }
 ];
 
@@ -153,6 +158,17 @@ export default function App() {
     );
   } else if (activePage === "partners") {
     pageContent = <PartnerLedgerPage />;
+  } else if (activePage === "invoices") {
+    pageContent = (
+      <section className="mx-auto flex w-full max-w-6xl px-6 py-8">
+        <div className="w-full rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center">
+          <h2 className="text-lg font-bold text-slate-900">請求書画面（準備中）</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            次のアクションでExcelライクな請求書画面を作り込みます。
+          </p>
+        </div>
+      </section>
+    );
   } else {
     pageContent = (
       <DriverLedgerPage


### PR DESCRIPTION
### Motivation
- Provide a navigation entry for an upcoming Excel-like invoice screen so users can reach the invoice area from the header. 

### Description
- Added `invoices` to the `ActivePage` union type and a new `請求書` entry in `NAV_ITEMS` so the header shows the button. 
- Added a new page branch for `invoices` in `App` that renders a dashed-border placeholder section describing the Excel-like invoice UI will be implemented next. 
- Changes were made in `client/src/App.tsx` and the new button uses the existing header nav flow to switch pages. 

### Testing
- Ran `npm run build` in `client/` and the build completed successfully. 
- Attempted to run the dev server and capture a screenshot with `npx playwright`, but `playwright` could not be installed (HTTP 403 from registry) so the automated screenshot step failed. 
- No unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f066e6328483228ae6c39f411b6a46)